### PR TITLE
Some updates about running simulation.

### DIFF
--- a/examples/sim_runner_example.py
+++ b/examples/sim_runner_example.py
@@ -18,15 +18,22 @@ netlist.add_instructions(
 )
 netlist.set_parameter('run', 0)
 
+tests = {}
+
 for opamp in ('AD712', 'AD820'):
     netlist.set_element_model('XU1', opamp)
     for supply_voltage in (5, 10, 15):
         netlist.set_component_value('V1', supply_voltage)
         netlist.set_component_value('V2', -supply_voltage)
         print("simulating OpAmp", opamp, "Voltage", supply_voltage)
-        LTC.run(netlist)
+        testName = f"{opamp}_{supply_voltage}V"
+        tests[testName] = LTC.run(netlist)
 
-for raw, log in LTC:
+LTC.wait_completion()
+
+for test in tests.keys():
+    raw, log = tests[test]
+    print("Test conditions %s" % test)
     print("Raw file: %s, Log file: %s" % (raw, log))
     # do something with the data
     # raw_data = RawRead(raw)

--- a/spicelib/LTSteps.py
+++ b/spicelib/LTSteps.py
@@ -87,7 +87,7 @@ __copyright__ = "Copyright 2023, Fribourg Switzerland"
 import os
 import sys
 
-from spicelib.log.ltsteps import *
+from .log.ltsteps import *
 import logging
 _logger = logging.getLogger("spicelib.LTSteps")
 

--- a/spicelib/__init__.py
+++ b/spicelib/__init__.py
@@ -6,6 +6,7 @@ from .raw.raw_write import RawWrite, Trace
 from .editor.spice_editor import SpiceEditor, SpiceCircuit
 from .editor.asc_editor import AscEditor
 from .sim.sim_runner import SimRunner
+from .simulators import LTspice, NGspice, Qspice, Xyce
 
 
 def all_loggers():

--- a/spicelib/editor/spice_editor.py
+++ b/spicelib/editor/spice_editor.py
@@ -758,7 +758,8 @@ class SpiceEditor(SpiceCircuit):
                 else:
                     i += 1
         elif get_line_command(instruction) == '.PARAM':
-            raise RuntimeError('The .PARAM instruction should be added using the "set_parameter" method')
+            # raise RuntimeError('The .PARAM instruction should be added using the "set_parameter" method')
+            _logger.warning('The .PARAM instruction should be added using the "set_parameter" method')
 
         # check whether the instruction is already there (dummy proofing)
         # TODO: if adding a .MODEL or .SUBCKT it should verify if it already exists and update it.

--- a/spicelib/editor/spice_editor.py
+++ b/spicelib/editor/spice_editor.py
@@ -681,6 +681,8 @@ class SpiceEditor(SpiceCircuit):
     def __init__(self, netlist_file: Union[str, Path], encoding='autodetect', create_blank=False):
         super().__init__()
         self.netlist_file = Path(netlist_file)
+        if self.circuit_file.suffix != '.net':
+            _logger.warning(f"Netlist file with wrong suffix {self.netlist_file.suffix}")
         self.modified_subcircuits = {}
         self.create_blank = create_blank
         if encoding == 'autodetect':

--- a/spicelib/sim/run_task.py
+++ b/spicelib/sim/run_task.py
@@ -108,7 +108,7 @@ class RunTask(threading.Thread):
         self.log_file = self.netlist_file.with_suffix('.log')
 
         # Cleanup everything
-        if self.retcode == 0:
+        if self.retcode == 0 and self.netlist_file.exists():
             # simulation successful
             self.print_info(_logger.info, "Simulation Successful. Time elapsed: %s" % sim_time)
             self.raw_file = self.netlist_file.with_suffix(self.simulator.raw_extension)

--- a/spicelib/sim/sim_runner.py
+++ b/spicelib/sim/sim_runner.py
@@ -334,7 +334,7 @@ class SimRunner(object):
             callback: Union[Type[ProcessCallback], Callable] = None,
             callback_args: Union[tuple, dict] = None,
             switches=None,
-            timeout: float = None, run_filename: str = None) -> Union[RunTask, None]:
+            timeout: float = None, run_filename: str = None) -> (str, str):
         """
         Executes a simulation run with the conditions set by the user.
         Conditions are set by the set_parameter, set_component_value or add_instruction functions.
@@ -371,9 +371,9 @@ class SimRunner(object):
         :param timeout:
             Timeout to be used in waiting for resources. Default time is value defined in this class constructor.
         :type timeout: float, optional
-        :param run_filename: Name to be used for the log and raw file.
-        :type run_filename: str or Path
-        :returns: The task object of type RunTask
+        :param run_filename: Name for output files. It should have '.net' suffix.
+        :type run_filename: str, optional
+        :returns: the raw and log filenames
         """
         callback_kwargs = self.validate_callback_args(callback, callback_args)
         if switches is None:
@@ -394,7 +394,7 @@ class SimRunner(object):
                 self.active_tasks.append(t)
                 t.start()
                 sleep(0.01)  # Give slack for the thread to start
-                return t  # Returns the task object
+                return t.raw_file, t.log_file  # Returns the raw and log file
             sleep(0.1)  # Give Time for other simulations to end
         else:
             _logger.error("Timeout waiting for resources for simulation %d" % self.runno)

--- a/spicelib/simulators/__init__.py
+++ b/spicelib/simulators/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Convenience direct imports
-from ltspice_simulator import LTspice
-from ngspice_simulator import NGspiceSimulator as NGspice
-from qspice_simulator import Qspice
-from xyce_simulator import XyceSimulator as Xyce
+from .ltspice_simulator import LTspice
+from .ngspice_simulator import NGspiceSimulator as NGspice
+from .qspice_simulator import Qspice
+from .xyce_simulator import XyceSimulator as Xyce

--- a/spicelib/simulators/__init__.py
+++ b/spicelib/simulators/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+# Convenience direct imports
+from ltspice_simulator import LTspice
+from ngspice_simulator import NGspiceSimulator as NGspice
+from qspice_simulator import Qspice
+from xyce_simulator import XyceSimulator as Xyce

--- a/spicelib/simulators/ltspice_simulator.py
+++ b/spicelib/simulators/ltspice_simulator.py
@@ -26,7 +26,7 @@ from typing import Union
 import logging
 _logger = logging.getLogger("spicelib.LTSpiceSimulator")
 
-from ..sim.simulator import Simulator, run_function
+from ..sim.simulator import Simulator, run_function, SpiceSimulatorError
 
 
 class LTspice(Simulator):
@@ -72,11 +72,6 @@ class LTspice(Simulator):
                 break
         else:
             spice_exe = []
-            _logger.error("================== ALERT! ====================")
-            _logger.error("Unable to find a LTSpice executable.")
-            _logger.error("A specific location of the LTSPICE can be set")
-            _logger.error("using the create_from(<location>) class method")
-            _logger.error("==============================================")
 
         process_name = "XVIIx64.exe"
 
@@ -166,6 +161,13 @@ class LTspice(Simulator):
 
     @classmethod
     def run(cls, netlist_file, cmd_line_switches, timeout):
+        if not cls.spice_exe:
+            _logger.error("================== ALERT! ====================")
+            _logger.error("Unable to find a LTSpice executable.")
+            _logger.error("A specific location of the LTSPICE can be set")
+            _logger.error("using the create_from(<location>) class method")
+            _logger.error("==============================================")
+            raise SpiceSimulatorError("Simulator executable not found.")
         if sys.platform == 'darwin':
             cmd_run = cls.spice_exe + ['-b'] + [netlist_file] + cmd_line_switches
         else:

--- a/spicelib/simulators/ltspice_simulator.py
+++ b/spicelib/simulators/ltspice_simulator.py
@@ -26,7 +26,7 @@ from typing import Union
 import logging
 _logger = logging.getLogger("spicelib.LTSpiceSimulator")
 
-from spicelib.sim.simulator import Simulator, run_function
+from ..sim.simulator import Simulator, run_function
 
 
 class LTspice(Simulator):

--- a/spicelib/simulators/ngspice_simulator.py
+++ b/spicelib/simulators/ngspice_simulator.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import logging
 _logger = logging.getLogger("spicelib.NGSpiceSimulator")
 
-from spicelib.sim.simulator import Simulator, run_function
+from ..sim.simulator import Simulator, run_function
 
 
 class NGspiceSimulator(Simulator):

--- a/spicelib/simulators/qspice_simulator.py
+++ b/spicelib/simulators/qspice_simulator.py
@@ -25,7 +25,7 @@ from pathlib import Path
 import logging
 _logger = logging.getLogger("spicelib.QSpiceSimulator")
 
-from ..sim.simulator import Simulator, run_function
+from ..sim.simulator import Simulator, run_function, SpiceSimulatorError
 
 
 class Qspice(Simulator):
@@ -50,11 +50,6 @@ class Qspice(Simulator):
                 break
         else:
             spice_exe = []
-            _logger.error("================== ALERT! ====================")
-            _logger.error("Unable to find the QSPICE executable.")
-            _logger.error("A specific location of the LTSPICE can be set")
-            _logger.error("using the create_from(<location>) class method")
-            _logger.error("==============================================")
 
         process_name = "QSPICE64.exe"
 
@@ -108,6 +103,13 @@ class Qspice(Simulator):
 
     @classmethod
     def run(cls, netlist_file, cmd_line_switches, timeout):
+        if not cls.spice_exe:
+            _logger.error("================== ALERT! ====================")
+            _logger.error("Unable to find the QSPICE executable.")
+            _logger.error("A specific location of the QSPICE can be set")
+            _logger.error("using the create_from(<location>) class method")
+            _logger.error("==============================================")
+            raise SpiceSimulatorError("Simulator executable not found.")
         log_file = Path(netlist_file).with_suffix('.log').as_posix()
         cmd_run = cls.spice_exe + ['-o', log_file] + [netlist_file] + cmd_line_switches
         # start execution

--- a/spicelib/simulators/qspice_simulator.py
+++ b/spicelib/simulators/qspice_simulator.py
@@ -25,7 +25,7 @@ from pathlib import Path
 import logging
 _logger = logging.getLogger("spicelib.QSpiceSimulator")
 
-from spicelib.sim.simulator import Simulator, run_function
+from ..sim.simulator import Simulator, run_function
 
 
 class Qspice(Simulator):

--- a/spicelib/simulators/xyce_simulator.py
+++ b/spicelib/simulators/xyce_simulator.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Union
 import logging
 _logger = logging.getLogger("spicelib.XYCESimulator")
-from spicelib.sim.simulator import Simulator, run_function
+from ..sim.simulator import Simulator, run_function
 
 
 class XyceSimulator(Simulator):


### PR DESCRIPTION
## Overview
**These updates are meant to solve the following problems:**
1. Bugs about the netlist name.
2. A 'simulator.exe' was given to a simulator class, but it still alerts when initialized.
3. When running simulations in parallel, it's difficult for the user to know the correspondence between outputs and netlist files.
4. Minor revisions to convenience users.

## Details.

#### 1. Bug about the netlist name.
**What happened:**

If we give a wrong netlist file name.
For example 1: `netlist=SpiceEditor("wrong_suffix.cir")`; 
Example 2: 
``` Python
runner = SimRunner()
runner.run(xxx, run_filename = "without_suffix_or_wrong_suffix")
```
There will be no warning message. (Especially, referring to this `:param run_filename: Name to be used for the log and raw file.`, it's hard for a user to know it should be with the '.net' suffix).

But in `SimRunner.run() -> self._prepare_sim(xxx) -> netlist.write_netlist(run_netlist_file)`, the netlist file name is forced to with '.net' suffix. At the same time, `run_netlist_file` remains unchanged.

So the LTspice.exe can not find "the netlist file", the simulation will not run.

**Futhermore:**
I found that the LTSpice.exe will still return 0 (succeed code) even if it cannot find the netlist file. So this program will only report that "raw and log file not found," but this is misleading.

**What I did:**
Add suffix and naming validity checking in `SimRunner._run_file_name()` to prevent the naming consistency. Corrected the documentation of param run_filename.

**Effectiveness:**
Now, it can support different netlist file suffixes but still has a warning if it's not '.net'.


#### 2. Simulator class unwanted alerts when initialized.
**What happened:**
In `ltspice_simulator.py` and `qspice_simulator.py`, if the system path cannot find corresponding executables (in Windows system paths), it will alert when it's first imported. I found it annoying.
**What I did:**
Move the alerting codes into `simulator.run()` from the class initialization.
If the user has already called `simulator.create_from()` method to specify an executable, it will not alert.
**What I did next:**
I found it inconvenient for the user to import the LTspice class. Previously the user should write like this:
```
from spicelib.simulator.ltspice_simulator import LTSpice
```
So, I optimized the convenience of direct imports.


#### 3. Difficulty in configuring parallel simulations.
**What's the problem:**
The user may use a for loop to call `SimRunner.run()` with several netlist files.
However, after all simulations are completed, the '.raw' and '.log' files may have different filenames than the user expected. 
(Because the files may be renamed to `"%s_%i%s" % ( Path(netlist).stem(), SimRunner.runno, Path(netlist).suffix()`.)
So the user cannot know the correspondence between a raw file and a netlist file.

**What I did:**
The user can use the return of `run` or `run_now` methods to build a mapping of netlist and output files.
The `SimRunner.run()` returns a RunTask instance, while the `SimRunner.run_now()` returns `(RunTask.raw, RunTask.log)`. I think the latter return is better because you said in `RunTask`: 
> """This is an internal Class and should not be used directly by the User."""

So I changed the return of `run()` to the same as `run_now()`. Now the user can know the relationship between output files and input netlists by doing like this:
``` Python
output_raw_file, output_log_file = inst_SimRunner.run(netlist = input_netlist)
in_out_mapping = {input_netlist.netlist_file: (output_raw_file, output_log_file)}
```

**There's a new problem** that although the user can know the raw filename when they run a simulation, the raw file may not be ready because the simulation may be still running in another thread or process.
So the user should wait for the simulation to complete and then do the data processing.
I updated the example file `examples/sim_runner_example.py` and added this:
``` Python
LTC = SimRunner()
...
LTC.wait_completion()
```


---
I hope these changes can improve the experience of the user.