### PR TITLE
Simplify `DataSet`'s `__str__()` method and add `__str__()` to `DummyTrace`

### DIFF
--- a/spicelib/raw/raw_classes.py
+++ b/spicelib/raw/raw_classes.py
@@ -55,14 +55,7 @@ class DataSet(object):
             raise NotImplementedError
 
     def __str__(self):
-        if isinstance(self.data[0], float):
-            # data = ["%e" % value for value in self.data]
-            return "name:'%s'\ntype:'%s'\nlen:%d\n%s" % (self.name, self.whattype, len(self.data), str(self.data))
-        elif isinstance(self.data[0], complex):
-            return "name: {}\ntype: {}\nlen: {:d}\n{}".format(self.name, self.whattype, len(self.data), str(self.data))
-        else:
-            data = [b2a_hex(value) for value in self.data]
-            return "name:'%s'\ntype:'%s'\nlen:%d\n%s" % (self.name, self.whattype, len(self.data), str(data))
+            return "name:'%s'\ntype:'%s'\nlen:%d" % (self.name, self.whattype, len(self.data))
 
     def __len__(self):
         return len(self.data)

--- a/spicelib/raw/raw_classes.py
+++ b/spicelib/raw/raw_classes.py
@@ -55,7 +55,7 @@ class DataSet(object):
             raise NotImplementedError
 
     def __str__(self):
-            return "name:'%s'\ntype:'%s'\nlen:%d" % (self.name, self.whattype, len(self.data))
+            return f"name:'{self.name}'\ntype:'{self.whattype}'\nlen:{len(self.data)}"
 
     def __len__(self):
         return len(self.data)

--- a/spicelib/raw/raw_classes.py
+++ b/spicelib/raw/raw_classes.py
@@ -23,7 +23,6 @@ Defines base classes for the RAW file data structures.
 """
 import numpy as np
 from numpy import zeros, complex128, float32, float64
-from binascii import b2a_hex
 from typing import Union, List
 
 

--- a/spicelib/raw/raw_classes.py
+++ b/spicelib/raw/raw_classes.py
@@ -353,6 +353,9 @@ class DummyTrace(object):
         self.datalen = datalen
         self.numerical_type = numerical_type
 
+    def __str__(self):
+        return f"name:'{self.name}'\ntype:'{self.whattype}'\nlen:{self.datalen}"
+
 
 class SpiceReadException(Exception):
     """Custom class for exception handling"""

--- a/spicelib/raw/raw_classes.py
+++ b/spicelib/raw/raw_classes.py
@@ -54,7 +54,7 @@ class DataSet(object):
             raise NotImplementedError
 
     def __str__(self):
-            return f"name:'{self.name}'\ntype:'{self.whattype}'\nlen:{len(self.data)}"
+        return f"name:'{self.name}'\ntype:'{self.whattype}'\nlen:{len(self.data)}"
 
     def __len__(self):
         return len(self.data)


### PR DESCRIPTION
* I propose `DataSet`'s `__str__()` not print out all the contents of a `.raw` file as they can be quite big.
* Add `__str__()` to `DummyTrace`

There was a line in `raw_read.py` which printed this information `print(trace)`, but it's been removed (I'm not against it 😄 ). 