### PR TITLE
Fix minor bug in timeout setting.

### DIFF
--- a/spicelib/sim/sim_runner.py
+++ b/spicelib/sim/sim_runner.py
@@ -378,7 +378,7 @@ class SimRunner(object):
 
             if (wait_resource is False) or (self.active_threads() < self.parallel_sims):
                 t = RunTask(self.simulator, self.runno, run_netlist_file, callback, callback_kwargs,
-                            cmdline_switches, timeout=self.timeout, verbose=self.verbose)
+                            cmdline_switches, timeout=timeout, verbose=self.verbose)
                 self.active_tasks.append(t)
                 t.start()
                 sleep(0.01)  # Give slack for the thread to start


### PR DESCRIPTION
Otherwise, the timeout setting in `simulator.run()` will not work.