### PR TITLE
Allow for parsing a specific case of measure

### DIFF
--- a/spicelib/log/ltsteps.py
+++ b/spicelib/log/ltsteps.py
@@ -312,9 +312,11 @@ class LTSpiceLogReader(LogfileData):
         # vin_rms: RMS(v(in))=0.70622 FROM 0 TO 0.001  => Interval
         # gain: vout_rms/vin_rms=1.99809 => Parameter
         # vout1m: v(out)=-0.0186257 at 0.001 => Point
+        # fcut: v(vout)=vmax/sqrt(2) AT 252.921
         # fcutac=8.18166e+006 FROM 1.81834e+006 TO 1e+007 => AC Find Computation
         regx = re.compile(
-                r"^(?P<name>\w+)(:\s+.*)?=(?P<value>[\d(inf)\.E+\-\(\)dB,°]+)(( FROM (?P<from>[\d\.E+-]*) TO (?P<to>[\d\.E+-]*))|( at (?P<at>[\d\.E+-]*)))?",
+                # r"^(?P<name>\w+)(:\s+.*)?=(?P<value>[\d(inf)\.E+\-\(\)dB,°]+)(( FROM (?P<from>[\d\.E+-]*) TO (?P<to>[\d\.E+-]*))|( at (?P<at>[\d\.E+-]*)))?",
+                r"^(?P<name>\w+)(:\s+.*)?=(?P<value>[\d(inf)E+\-\(\)dB,°(-/\w]+)( FROM (?P<from>[\d\.E+-]*) TO (?P<to>[\d\.E+-]*)|( at (?P<at>[\d\.E+-]*)))?",
                 re.IGNORECASE)
 
         _logger.debug(f"Processing LOG file:{log_filename}")


### PR DESCRIPTION
+ fcut: v(vout)=vmax/sqrt(2) AT 252.921
I added characters ( through / to the <value> regex [(-/]
as well as complete words [\w]

I am not sure how it could affect more complicated measures, I just see it passes on all the test cases shown in the source.
![image](https://github.com/nunobrum/spicelib/assets/8996551/09ce3c74-dbea-4bad-a842-65d748313dad)

Thank you for your work!
