### PR TITLE
Improve exception message raised by callback function

### DIFF
--- a/spicelib/sim/run_task.py
+++ b/spicelib/sim/run_task.py
@@ -126,8 +126,8 @@ class RunTask(threading.Thread):
                             return_or_process = self.callback(self.raw_file, self.log_file, **self.callback_args)
                         else:
                             return_or_process = self.callback(self.raw_file, self.log_file)
-                    except Exception as err:
-                        error = traceback.format_tb(err.__traceback__)
+                    except Exception:
+                        error = traceback.format_exc()
                         self.print_info(_logger.error, error)
                     else:
                         if isinstance(return_or_process, ProcessCallback):


### PR DESCRIPTION
If the callback function raises an exception, for example `AttributeError`, then the message will only show the traceback, but not the exception.

Usually the exception has a very nice message explaining why the exception was raised. In my case I was calling a method which didn't exist. It wasn't clear until I got the exception message with `format_exc`

To reproduce, simply create a Python exception in the `self.callback` function.