### PR TITLE
Update asc_editor.py to fix iteration error in get_component_info

### DIFF
--- a/spicelib/editor/asc_editor.py
+++ b/spicelib/editor/asc_editor.py
@@ -251,7 +251,7 @@ class AscEditor(BaseSchematic):
     def get_component_info(self, reference) -> dict:
         """Returns the reference information as a dictionary"""
         component = self.get_component(reference)
-        info = {name: value for name, value in component.attributes if not name.startswith("WINDOW ")}
+        info = {name: value for name, value in component.attributes.items() if not name.startswith("WINDOW ")}
         info["InstName"] = reference  # For legacy purposes
         return info
 


### PR DESCRIPTION
Change get_component_info to iterate over the key, value pairs in the component.attributes dictionary.  Previously, it iterated directly on the dictionary, which in recent versions of Python is equivalent to iterating over only the keys.