### PR TITLE
Fix for Rawread: LTspice double precision

### DIFF
--- a/spicelib/raw/raw_read.py
+++ b/spicelib/raw/raw_read.py
@@ -447,6 +447,9 @@ class RawRead(object):
         else:
             if reading_qspice:  # QSPICE uses doubles for everything
                 numerical_type = 'double'
+
+            elif "double" in self.raw_params['Flags']: # Ltspice: .options numdgt = 7 sets this flag for double precision
+                numerical_type = 'double'               
             else:
                 numerical_type = 'real'
         i = header.index('Variables:')


### PR DESCRIPTION
Hello,
Setting the double precision flag (.options numdgt = 7.)  in Ltspice leads to this erorr.
- RuntimeError: Error in calculating the block size. Expected 16 bytes, but found 24 bytes

Rawread does not support Ltspice double precision. I added a simple check for double precision flag which solves this issue.

I included a simple file with the error and a jupyter notebook checking the issue. I did run the unitest for rawread however i also see it dont cover ltspice i think.

To reduce risk between spice versions, maybe a check if is ltspice should be included but i did not see any such details inside a Ltspice rawfile.

[00 Investigation Ltspice python double precision.zip](https://github.com/nunobrum/spicelib/files/15496734/00.Investigation.Ltspice.python.double.precision.zip)
