### PR TITLE
Better integrate ngspice

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,11 @@ simulation can be run from there.
 
 #### Windows, Linux and MacOS compatibility ####
 
-The LTspice class tries to detect the correct path of the LTspice installation depending on the platform. On Linux it expects LTspice to be installed under wine. On MacOS, it first looks for LTspice installed under wine, and when it cannot be found, it will look for native LTspice. The reason is that the command line interface of the native LTspice is severely limited.
+The **LTspice** class tries to detect the correct path of the LTspice installation depending on the platform. On Linux it expects LTspice to be installed under wine. On MacOS, it first looks for LTspice installed under wine, and when it cannot be found, it will look for native LTspice. The reason is that the command line interface of the native LTspice is severely limited.
 
-For the other simulators, linux support is coming.
+**NGSpice** runs natively under Windows, Linux and MacOS (via brew). This library works with NGSpice CLI, and tries to detect the correct executable path, no matter the platform. It cannot (yet) work with the shared library version of ngspice that is delivered with for example Kicad, you will need to install the CLI version. You can however use Kicad as the schema editor and subsequently save the ngspice netlist to use it with this library.
+
+For the other simulators, built-in Linux/MacOS support is coming, but you can always try to use it under Linux via setting of the executable paths.
 
 #### Executable and Library paths ####
 

--- a/spicelib/raw/raw_read.py
+++ b/spicelib/raw/raw_read.py
@@ -442,8 +442,11 @@ class RawRead(object):
         
         reading_ltspice = 'Command' in self.raw_params and 'ltspice' in self.raw_params['Command'].lower()
         reading_qspice = 'Command' in self.raw_params and 'qspice' in self.raw_params['Command'].lower()
-        reading_ngspice = 'Command' in self.raw_params and 'ngspice' in self.raw_params['Command'].lower()  # this will only work from ngspice 44 on. Older version do likely not have the "Command" line
+        reading_ngspice = 'Command' in self.raw_params and 'ngspice' in self.raw_params['Command'].lower()  # this will only work from ngspice 44 on. 
         # TODO: add xyce
+        
+        if not (reading_ltspice or reading_qspice):  # TODO: remove this section once ngspice 44+ is commonplace. Older versions did not print the 'Command' line
+            reading_ngspice = True
         
         self._traces = []
         self.steps = None
@@ -452,10 +455,7 @@ class RawRead(object):
         if 'complex' in self.raw_params['Flags'] or self.raw_params['Plotname'] == 'AC Analysis':
             numerical_type = 'complex'
         else:
-            if reading_qspice:  # QSPICE uses doubles for everything
-                numerical_type = 'double'
-            elif reading_ngspice or not (reading_ltspice or reading_qspice):  # ngspice uses doubles. 
-                # TODO: remove the last condition `or not (reading_ltspice or reading_qspice)` once ngspice 44+ is commonplace. Older versions did not print the command line
+            if reading_qspice or reading_ngspice:  # QSPICE and ngspice use doubles for everything
                 numerical_type = 'double'
             elif reading_ltspice and "double" in self.raw_params['Flags']:  # LTspice: .options numdgt = 7 sets this flag for double precision
                 numerical_type = 'double'

--- a/spicelib/raw/raw_read.py
+++ b/spicelib/raw/raw_read.py
@@ -913,7 +913,7 @@ class RawRead(object):
         :param columns: List of traces to use as columns. Default is all traces
         :type columns: list
         :param kwargs: Additional arguments to pass to the pandas.DataFrame constructor
-        :type kwargs: \*\*dict
+        :type kwargs: **dict
         :return: A pandas DataFrame
         :rtype: pandas.DataFrame
         """
@@ -939,7 +939,7 @@ class RawRead(object):
         :param separator: separator to use in the CSV file
         :type separator: str
         :param kwargs: Additional arguments to pass to the pandas.DataFrame.to_csv function
-        :type kwargs: \*\*dict
+        :type kwargs: **dict
         """
         try:
             import pandas as pd

--- a/spicelib/raw/raw_read.py
+++ b/spicelib/raw/raw_read.py
@@ -762,13 +762,15 @@ class RawRead(object):
 
     def _load_step_information(self, filename: Path):
         if 'Command' not in self.raw_params:
-            # probably ngspice. Due to a lack of test data,  cannot (yet) create a correct implementation.
+            # probably ngspice before v44. And anyway, ngspice does not support the '.step' directive
+            # FYI: ngspice can do something like .step via a control section with while loop.
             raise SpiceReadException("Unsupported simulator. Only LTspice and QSPICE are supported.")
-        # Find the extension of the file
-        # if it is an LTspice generated file, it should have a .log file with the same name
-        if 'LTspice' in self.raw_params['Command']:
+        
+        if 'ltspice' in self.raw_params['Command'].lower():
+            # look in the .log file for information about the steps
             if filename.suffix != '.raw':
                 raise SpiceReadException("Invalid Filename. The file should end with '.raw'")
+            # it should have a .log file with the same name        
             logfile = filename.with_suffix(".log")
             try:
                 encoding = detect_encoding(logfile, "^(.*\n)?Circuit:")
@@ -790,9 +792,11 @@ class RawRead(object):
                         self.steps.append(step_dict)
             log.close()
 
-        elif 'QSPICE' in self.raw_params['Command']:
+        elif 'qspice' in self.raw_params['Command'].lower():
+            # look in the .log file for information about the steps
             if filename.suffix != '.qraw':
                 raise SpiceReadException("Invalid Filename. The file should end with '.qraw'")
+            # it should have a .log file with the same name        
             logfile = filename.with_suffix(".log")
             try:
                 log = open(logfile, 'r', errors='replace', encoding='utf-8')

--- a/spicelib/sim/simulator.py
+++ b/spicelib/sim/simulator.py
@@ -22,7 +22,7 @@
 import sys
 from abc import ABC, abstractmethod
 from pathlib import Path, PureWindowsPath
-from typing import Optional, List
+from typing import Union, Optional, List
 import subprocess
 import os
 import logging
@@ -83,7 +83,7 @@ class Simulator(ABC):
     .. code-block:: python
         
         @classmethod
-        def run(cls, netlist_file, cmd_line_switches, timeout):
+        def run(cls, netlist_file: Union[str, Path], cmd_line_switches: list = None, timeout: float = None, stdout=None, stderr=None):
             '''This method implements the call for the simulation of the netlist file. '''
             cmd_run = cls.spice_exe + ['-Run'] + ['-b'] + [netlist_file] + cmd_line_switches
             return run_function(cmd_run, timeout=timeout)
@@ -158,7 +158,7 @@ class Simulator(ABC):
 
     @classmethod
     @abstractmethod
-    def run(cls, netlist_file, cmd_line_switches, timeout):
+    def run(cls, netlist_file: Union[str, Path], cmd_line_switches: list = None, timeout: float = None, stdout=None, stderr=None) -> int:
         """This method implements the call for the simulation of the netlist file. This should be overriden by its
         subclass."""
         raise SpiceSimulatorError("This class should be subclassed and this function should be overridden.")

--- a/spicelib/simulators/ltspice_simulator.py
+++ b/spicelib/simulators/ltspice_simulator.py
@@ -219,7 +219,7 @@ class LTspice(Simulator):
             raise ValueError("Invalid switch for class ")
 
     @classmethod
-    def run(cls, netlist_file: Union[str, Path], cmd_line_switches: list = None, timeout: float = None, stdout=None, stderr=None):
+    def run(cls, netlist_file: Union[str, Path], cmd_line_switches: list = None, timeout: float = None, stdout=None, stderr=None) -> int:
         """Executes a LTspice simulation run.
 
         :param netlist_file: path to the netlist file

--- a/spicelib/simulators/ngspice_simulator.py
+++ b/spicelib/simulators/ngspice_simulator.py
@@ -138,7 +138,7 @@ class NGspiceSimulator(Simulator):
         return ret
 
     @classmethod
-    def run(cls, netlist_file: Union[str, Path], cmd_line_switches: list = None, timeout: float = None, stdout=None, stderr=None):
+    def run(cls, netlist_file: Union[str, Path], cmd_line_switches: list = None, timeout: float = None, stdout=None, stderr=None) -> int:
         """Executes a NGspice simulation run.
 
         :param netlist_file: path to the netlist file

--- a/spicelib/simulators/qspice_simulator.py
+++ b/spicelib/simulators/qspice_simulator.py
@@ -122,7 +122,7 @@ class Qspice(Simulator):
             raise ValueError("Invalid switch for class ")
 
     @classmethod
-    def run(cls, netlist_file: Union[str, Path], cmd_line_switches: list = None, timeout: float = None, stdout=None, stderr=None):
+    def run(cls, netlist_file: Union[str, Path], cmd_line_switches: list = None, timeout: float = None, stdout=None, stderr=None) -> int:
         """Executes a Qspice simulation run.
 
         :param netlist_file: path to the netlist file

--- a/spicelib/simulators/xyce_simulator.py
+++ b/spicelib/simulators/xyce_simulator.py
@@ -126,7 +126,7 @@ class XyceSimulator(Simulator):
         return ret
 
     @classmethod
-    def run(cls, netlist_file: Union[str, Path], cmd_line_switches: list = None, timeout: float = None, stdout=None, stderr=None):
+    def run(cls, netlist_file: Union[str, Path], cmd_line_switches: list = None, timeout: float = None, stdout=None, stderr=None) -> int:
         """Executes a LTspice simulation run.
 
         :param netlist_file: path to the netlist file


### PR DESCRIPTION
This PR allows a better integration with ngspice: calling and raw file reading is improved.
Unfortunately the present ngspice version did not clearly identify itself in the raw files, and some extra workarounds had to be added in this library. That workaround is no longer needed for future versions of ngspice (or right now 'pre-master-44'), as this behavior is corrected there.
It also has some small improvements around the Simulator.run() .