### PR TITLE
Improved crash issue in LTspice asy_reader with cosmetic text

### DIFF
--- a/spicelib/editor/asy_reader.py
+++ b/spicelib/editor/asy_reader.py
@@ -143,9 +143,17 @@ class AsyReader(object):
                     if len(line_elements) == 11:
                         arc.line_style.pattern = line_elements[10]
                     self.shapes.append(arc)
+
+                elif line.startswith("TEXT"):
+                    # Text in asy not supported however non-critical and not neccesary to crash the program.
+                    _logger.warning(f"Cosmetic text in ASY not supported, text skipped. ASY file: {self._asy_file_path}" 
+                                    )
+
+                    
                 else:
-                    raise NotImplementedError("Primitive not supported for ASY file\n" 
-                                              f'"{line}"')
+                    raise NotImplementedError(f"Primitive not supported for ASY file \n" 
+                                              f'"{line}"'
+                                              f'in file: {self._asy_file_path}')
             if pin is not None:
                 self.pins.append(pin)
 

--- a/spicelib/editor/asy_reader.py
+++ b/spicelib/editor/asy_reader.py
@@ -144,16 +144,27 @@ class AsyReader(object):
                         arc.line_style.pattern = line_elements[10]
                     self.shapes.append(arc)
 
-                elif line.startswith("TEXT"):
-                    # Text in asy not supported however non-critical and not neccesary to crash the program.
-                    _logger.warning(f"Cosmetic text in ASY not supported, text skipped. ASY file: {self._asy_file_path}" 
-                                    )
+                elif line.startswith("TEXT "):
+                    line_elements = line.split()
+                    if len(line_elements) == 6:
+                        x = int(line_elements[1])
+                        y = int(line_elements[2])
 
-                    
+                        text = Text(Point(x, y), text=line_elements[5], size=int(line_elements[4]),
+                                    type=TextTypeEnum.COMMENT,
+                                    textAlignment=HorAlign(line_elements[3]),
+                                    )
+                        self.windows.append(text)
+                    else:
+                        # Text in asy not supported however non-critical and not neccesary to crash the program.
+                        _logger.warning(f"Cosmetic text in ASY format not supported, text skipped. ASY file: {self._asy_file_path}"
+                                    )
                 else:
+                    # In order to avoid crashing the program, 1) add the missing if statement above and
+                    # 2) ontact the author to add support for the missing primitive.
                     raise NotImplementedError(f"Primitive not supported for ASY file \n" 
                                               f'"{line}"'
-                                              f'in file: {self._asy_file_path}')
+                                              f'in file: {self._asy_file_path}. Contact the author to add support.')
             if pin is not None:
                 self.pins.append(pin)
 

--- a/spicelib/simulators/ltspice_simulator.py
+++ b/spicelib/simulators/ltspice_simulator.py
@@ -118,8 +118,8 @@ class LTspice(Simulator):
     
     # The following variables are not needed anymore. This also makes sphinx not mention them in the documentation.
     del exe
-    del spice_folder
-    del spice_executable
+    #del spice_folder
+    #del spice_executable
             
     # fall through        
     if len(spice_exe) == 0:

--- a/spicelib/simulators/ltspice_simulator.py
+++ b/spicelib/simulators/ltspice_simulator.py
@@ -118,8 +118,9 @@ class LTspice(Simulator):
     
     # The following variables are not needed anymore. This also makes sphinx not mention them in the documentation.
     del exe
-    #del spice_folder
-    #del spice_executable
+    if sys.platform == "linux" or sys.platform == "darwin":
+        del spice_folder
+        del spice_executable
             
     # fall through        
     if len(spice_exe) == 0:


### PR DESCRIPTION
[spicelib bug text in sub circuit asy.zip](https://github.com/user-attachments/files/16840586/spicelib.bug.text.in.sub.circuit.asy.zip)

AsyReader seems unnescsary strict with LTspice sub circuit where the ASY contains a text. 
"
    raise NotImplementedError("Primitive not supported for ASY file\n"
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
NotImplementedError: Primitive not supported for ASY file
"TEXT -23 -15 Left 2 test
"

Caused by having a text in the drawing in the subcircuit .asy see attached file for issue and after the fix it works. 
Not sure how to fix this in a better way.

spicelib/editor/asy_reader.py:
The fix add some additional details about which asy causes issues and instead of failing to run a simulation due to what i think is mainly a cosmetic issue (which i also think might not be used if the sub circuit is not changed), prints a warning. 


spicelib/simulators/ltspice_simulator.py:
There was also a unrelated issue with del spice_folder del spice_executable not being defined / leftover from somewhere else so that ended up being included here also to be able to test the fix.
