### PR TITLE
Qspice support for switch (S device)

### DIFF
--- a/spicelib/editor/qsch_editor.py
+++ b/spicelib/editor/qsch_editor.py
@@ -400,7 +400,7 @@ class QschEditor(BaseSchematic):
             texts = symbol_tag.get_items('text')
             nets = " ".join(component.ports)
 
-            if typ in ('R', 'D', 'C', 'L', 'V', 'I'):
+            if typ in ('R', 'D', 'C', 'L', 'V', 'I', 'S'):
                 value = texts[1].get_text_attr(QSCH_TEXT_STR_ATTR)
                 if len(texts) > 2:
                     for i in range(2, len(texts)):


### PR DESCRIPTION
QschEditor do not support switches (S device type). I added it to what i think is the relevant section in Qspice editor. 
- Simulation do not simulate before and seem to work correctly afterward.

See attached file for the problematic device.
[spicelib Qspice bug switch device in schematic.zip](https://github.com/user-attachments/files/16922563/spicelib.Qspice.bug.switch.device.in.schematic.zip)
