### PR TITLE
doc: repair broken links and simplify class names

### DIFF
--- a/doc/classes/asc_editor.rst
+++ b/doc/classes/asc_editor.rst
@@ -3,7 +3,7 @@ AscEditor
 
 Class used for manipulating LTSpice asc files.
 
-.. autoclass:: spicelib.editor.asc_editor.AscEditor
+.. autoclass:: spicelib.AscEditor
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/classes/qsch_editor.rst
+++ b/doc/classes/qsch_editor.rst
@@ -3,7 +3,7 @@ QschEditor
 
 Class used for manipulating QSPICE qsch files.
 
-.. autoclass:: spicelib.editor.qsch_editor.QschEditor
+.. autoclass:: spicelib.QschEditor
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/classes/raw_classes.rst
+++ b/doc/classes/raw_classes.rst
@@ -6,8 +6,7 @@ Raw and Log File Classes
    :maxdepth: 4
    
    raw_read
+   raw_write
    trace
    logreader
-   raw_write
-   write_trace
    

--- a/doc/classes/raw_read.rst
+++ b/doc/classes/raw_read.rst
@@ -1,7 +1,7 @@
 RawRead
 =======
 
-.. autoclass:: spicelib.raw.raw_read.RawRead
+.. autoclass:: spicelib.RawRead
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/classes/raw_write.rst
+++ b/doc/classes/raw_write.rst
@@ -1,7 +1,7 @@
 RawWrite
 ========
 
-.. autoclass:: spicelib.raw.raw_write.RawWrite
+.. autoclass:: spicelib.RawWrite
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/classes/spice_circuit.rst
+++ b/doc/classes/spice_circuit.rst
@@ -1,7 +1,7 @@
 SpiceCircuit
 ============
 
-.. autoclass:: spicelib.editor.spice_editor.SpiceCircuit
+.. autoclass:: spicelib.SpiceCircuit
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/classes/spice_editor.rst
+++ b/doc/classes/spice_editor.rst
@@ -3,7 +3,7 @@ SpiceEditor
 
 Class used for manipulating SPICE netlists. Inherits from SpiceCircuit.
 
-.. autoclass:: spicelib.editor.spice_editor.SpiceEditor
+.. autoclass:: spicelib.SpiceEditor
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/classes/trace.rst
+++ b/doc/classes/trace.rst
@@ -1,7 +1,12 @@
-RawRead Trace
-=============
+Axis, Trace and TraceRead
+=========================
 
 .. autoclass:: spicelib.raw.raw_classes.Axis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: spicelib.Trace
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/classes/write_trace.rst
+++ b/doc/classes/write_trace.rst
@@ -1,7 +1,0 @@
-RawWrite Trace
-==============
-
-.. autoclass:: spicelib.raw.raw_write.Trace
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/doc/modules/read_netlist.rst
+++ b/doc/modules/read_netlist.rst
@@ -106,5 +106,5 @@ Example 4: Updating components inside a subcircuit
 
 See the class documentation for more details :
 
-* :py:class:`spicelib.SpiceEditor`
-* :py:class:`spicelib.SpiceCircuit`
+- :py:class:`spicelib.SpiceEditor`
+- :py:class:`spicelib.SpiceCircuit`

--- a/doc/modules/read_rawfiles.rst
+++ b/doc/modules/read_rawfiles.rst
@@ -26,7 +26,7 @@ directory as the raw file in order to obtain the STEP information.
 You can get a list of all trace names using the ``get_trace_names()`` method.
 
 Use method ``get_trace()`` to get the trace data, which consists of values for 1 or more simulation steps.
-It will return a :py:class:`spicelib.raw_classes.Trace` object.  Use this object's ``get_wave()`` method to get
+It will return a :py:class:`spicelib.Trace` object.  Use this object's ``get_wave()`` method to get
 the actual data points for a step.
 
 Use the method ``get_axis()`` to get the 'time' data.  If there were multiple steps in the simulation, specify
@@ -38,8 +38,11 @@ Note that all the data will be returned as numpy arrays.
 
 See the class documentation for more details :
 
-- :py:class:`spicelib.raw_read.RawRead`
-- :py:class:`spicelib.raw_classes.Trace`
+- :py:class:`spicelib.RawRead`
+- :py:class:`spicelib.raw.raw_classes.Axis`
+- :py:class:`spicelib.Trace`
+- :py:class:`spicelib.raw.raw_classes.TraceRead`
+
 
 Example
 -------

--- a/doc/modules/write_rawfiles.rst
+++ b/doc/modules/write_rawfiles.rst
@@ -34,5 +34,5 @@ containing a 10kHz sine and a 9.997kHz cosine wave.
 For more information, see :
 
 - :doc:`../varia/raw_file`
-- :py:class:`spicelib.raw_write.RawWrite`
-- :py:class:`spicelib.raw_write.Trace`
+- :py:class:`spicelib.RawWrite`
+- :py:class:`spicelib.Trace`


### PR DESCRIPTION
This update repairs some broken links and standardises the class names.

example: `spicelib.editor.spice_editor.SpiceEditor` was mentioned, but also `spicelib.SpiceEditor`.
Since the user can just do `from spicelib import SpiceEditor`, I decided to make all class names in the doc according to how one can load them from an import: `spicelib.SpiceEditor` in the above case.

And I shuffled the Axis, Trace and TraceRead classes around a bit. The page names were strange.