### PR TITLE
Avoids crashing when libraries are encrypted

### DIFF
--- a/spicelib/editor/asc_editor.py
+++ b/spicelib/editor/asc_editor.py
@@ -108,8 +108,8 @@ class AscEditor(BaseSchematic):
                 asc.write(f"SYMATTR InstName {component.reference}" + END_LINE_TERM)
                 if component.reference.startswith('X') and "_SUBCKT" in component.attributes:
                     # writing the sub-circuit if it was updated
-                    sub_circuit: AscEditor = component.attributes["_SUBCKT"]
-                    if sub_circuit.updated:
+                    sub_circuit: AscEditor = component.attributes['_SUBCKT']
+                    if sub_circuit is not None and sub_circuit.updated:
                         sub_circuit.save_netlist(sub_circuit.asc_file_path)
                 for attr, value in component.attributes.items():
                     if not attr.startswith('_'):  # All these are not exported since they are only used internally
@@ -170,7 +170,7 @@ class AscEditor(BaseSchematic):
                         symbol = self._get_symbol(component.symbol)
                         if component.reference.startswith('X') or symbol.is_subcircuit():  # This is a subcircuit
                             # then create the attribute "SUBCKT"
-                            component.attributes["_SUBCKT"] = self._get_subcircuit(symbol)
+                            component.attributes['_SUBCKT'] = self._get_subcircuit(symbol)
                     else:
                         # make sure prefix is uppercase, as this is used in a lot of places
                         if ref.upper() == "PREFIX":
@@ -302,7 +302,7 @@ class AscEditor(BaseSchematic):
     def get_subcircuit(self, reference: str) -> 'AscEditor':
         """Returns an AscEditor file corresponding to the symbol"""
         sub = self.get_component(reference)
-        return sub.attributes["_SUBCKT"]
+        return sub.attributes['_SUBCKT']
 
     def get_component_info(self, reference) -> dict:
         """Returns the reference information as a dictionary"""

--- a/spicelib/editor/qsch_editor.py
+++ b/spicelib/editor/qsch_editor.py
@@ -378,8 +378,8 @@ class QschEditor(BaseSchematic):
         # now checks if there are subcircuits that need to be saved
         for component in self.components.values():
             if "_SUBCKT" in component.attributes:
-                sub_circuit = component.attributes["_SUBCKT"]
-                if sub_circuit.updated:
+                sub_circuit = component.attributes['_SUBCKT']
+                if sub_circuit is not None and sub_circuit.updated:
                     sub_circuit.save_as(sub_circuit._qsch_file_path)
 
     def write_spice_to_file(self, netlist_file: TextIO):

--- a/spicelib/editor/spice_editor.py
+++ b/spicelib/editor/spice_editor.py
@@ -1046,7 +1046,10 @@ class SpiceCircuit(BaseEditor):
         # 0. Setup things
         reg_subckt = re.compile(SUBCKT_CLAUSE_FIND + subckt_name, re.IGNORECASE)
         # 1. Find Encoding
-        encoding = detect_encoding(library)
+        try:
+            encoding = detect_encoding(library)
+        except EncodingDetectError:
+            return None
         #  2. scan the file
         with open(library, encoding=encoding) as lib:
             for line in lib:


### PR DESCRIPTION
When searching for a subcircuit, if a library is encrypted it just ignores it and avoids crashing the script.