### PR TITLE
toolkit save fix

### DIFF
--- a/examples/run_montecarlo.py
+++ b/examples/run_montecarlo.py
@@ -20,16 +20,20 @@ mc.set_tolerance('R1', 0.05)  # 5% tolerance for R1 only. This only overrides th
 mc.set_parameter_deviation('Vos', 3e-4, 5e-3, 'uniform')  # The keyword 'distribution' is optional
 mc.prepare_testbench(num_runs=1000)  # Prepares the testbench for 1000 simulations
 
-# Finally the netlist is saved to a file. This file contians all the instructions to run the simulation in LTspice
-mc.save_netlist('./testfiles/temp/sallenkey_mc.asc')
-# -- End of Example 1 --
+manually_simulating_in_LTspice = False
 
-mc.run_testbench(runs_per_sim=100)  # Runs the simulation with splits of 100 runs each
-logs = mc.read_logfiles()   # Reads the log files and stores the results in the results attribute
-logs.obtain_amplitude_and_phase_from_complex_values()  # Splits the complex values into real and imaginary parts
-logs.export_data('./temp_mc/data_testbench.csv')  # Exports the data to a csv file
-logs.plot_histogram('fcut')  # Plots the histograms for the results
-mc.cleanup_files()  # Deletes the temporary files
+if manually_simulating_in_LTspice:
+    # Finally the netlist is saved to a file. This file contains all the instructions to run the simulation in LTspice
+    mc.save_netlist('./testfiles/temp/sallenkey_mc.asc')
+    # -- End of Example 1 --
+else:
+    # Using the Toolkit to run the simulation.
+    mc.run_testbench(runs_per_sim=100)  # Runs the simulation with splits of 100 runs each
+    logs = mc.read_logfiles()   # Reads the log files and stores the results in the results attribute
+    logs.obtain_amplitude_and_phase_from_complex_values()  # Splits the complex values into real and imaginary parts
+    logs.export_data('./temp_mc/data_testbench.csv')  # Exports the data to a csv file
+    logs.plot_histogram('fcut')  # Plots the histograms for the results
+    mc.cleanup_files()  # Deletes the temporary files
 
 print("=====================================")
 # Now using the second method, where the simulations are ran one by one
@@ -40,4 +44,3 @@ logs = mc.read_logfiles()   # Reads the log files and stores the results in the 
 logs.export_data('./temp_mc/data_sims.csv')  # Exports the data to a csv file
 logs.plot_histogram('fcut')  # Plots the histograms for the results
 mc.cleanup_files()  # Deletes the temporary files
-

--- a/spicelib/sim/tookit/tolerance_deviations.py
+++ b/spicelib/sim/tookit/tolerance_deviations.py
@@ -184,6 +184,8 @@ class ToleranceDeviations(SimAnalysis, ABC):
             super()._reset_netlist()
             self.play_instructions()
             self.prepare_testbench()
+        else:
+            self.play_instructions()
         self.editor.remove_instruction(".step param run -1 %d 1" % self.last_run_number)  # Needs to remove this instruction
         self.clear_simulation_data()
         # calculate the ideal number of runs per simulation to avoid orphan runs. This is to avoid having a simulation


### PR DESCRIPTION
Being able to use the run_testbench just after a prepare_testbench without having to call save_netlist first.