### PR TITLE
Accept .txt model files, see #132

### DIFF
--- a/spicelib/editor/asy_reader.py
+++ b/spicelib/editor/asy_reader.py
@@ -273,11 +273,9 @@ class AsyReader(object):
     def get_library(self) -> str:
         """Returns the library name of the model. If not found, returns None."""
         # Searching in this exact order
+        suffixes = ('.lib', '.sub', '.cir', '.txt')
         for attr in ('ModelFile', 'SpiceModel', 'SpiceLine', 'SpiceLine2', 'Def_Sub', 'Value', 'Value2'):
-            if attr in self.attributes and (self.attributes[attr].endswith('.lib') or
-                                            self.attributes[attr].endswith('.sub') or
-                                            self.attributes[attr].endswith('.cir') or 
-                                            self.attributes[attr].endswith('.txt')):
+            if attr in self.attributes and (self.attributes[attr].endswith(suffixes)):
                 return self.attributes[attr]
         return self.attributes.get('SpiceModel')
 

--- a/spicelib/editor/asy_reader.py
+++ b/spicelib/editor/asy_reader.py
@@ -276,7 +276,8 @@ class AsyReader(object):
         for attr in ('ModelFile', 'SpiceModel', 'SpiceLine', 'SpiceLine2', 'Def_Sub', 'Value', 'Value2'):
             if attr in self.attributes and (self.attributes[attr].endswith('.lib') or
                                             self.attributes[attr].endswith('.sub') or
-                                            self.attributes[attr].endswith('.cir')):
+                                            self.attributes[attr].endswith('.cir') or 
+                                            self.attributes[attr].endswith('.txt')):
                 return self.attributes[attr]
         return self.attributes.get('SpiceModel')
 
@@ -304,6 +305,9 @@ class AsyReader(object):
         return ans
 
     def get_schematic_file(self):
+        """
+        Returns the file name of the component, if it were a .asc file
+        """        
         assert self._asy_file_path.suffix == '.asy', "File is not an asy file"
         assert self.symbol_type == 'BLOCK', "File is not a sub-circuit"
         return self._asy_file_path.with_suffix('.asc')


### PR DESCRIPTION
Some models are in .txt format. Adding that. See #132.