### PR TITLE
159 get all parameter names method

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,12 +821,13 @@ For support and improvement requests please open an Issue in [GitHub spicelib is
 
 * Version TBD
   * Fixed Issue #139 - support xyce raw files
+  * Added `get_all_parameter_names()` function to all editors (#159)
 * Version 1.4.0 (Python 3.9+ only)
   * Fixed Issue #152 - python version compatibility too limited on PyPi.
 * Version 1.3.8
   * Solving deprecation in GitHub artifact actions v3 -> v4
 * Version 1.3.7
-  * Fixed Issue #143 - ltsteps example fixed 
+  * Fixed Issue #143 - ltsteps example fixed
   * Fixed Issue #141 - Raw file reader cannot handle complex values (AC analysis) in ASCII RAW files
   * Fixed Issue #140 and #131 - Compatibility with LTspice 24+
   * Fixed Issue #145 - Allow easy hiding of simulator's console message

--- a/spicelib/editor/asc_editor.py
+++ b/spicelib/editor/asc_editor.py
@@ -332,7 +332,19 @@ class AscEditor(BaseSchematic):
                     if match.group("name").upper() == param_name_uppercase:
                         return match, directive
         return None, None
-
+    
+    def get_all_parameter_names(self) -> List[str]:
+        # docstring inherited from BaseEditor
+        param_names = []
+        search_expression = re.compile(PARAM_REGEX(r"\w+"), re.IGNORECASE)
+        for directive in self.directives:
+            if directive.text.upper().startswith(".PARAM"):
+                matches = search_expression.finditer(directive.text)
+                for match in matches:            
+                    param_name = match.group('name')
+                    param_names.append(param_name.upper())
+        return sorted(param_names)
+    
     def get_parameter(self, param: str) -> str:
         match, directive = self._get_param_named(param)
         if match:

--- a/spicelib/editor/asc_editor.py
+++ b/spicelib/editor/asc_editor.py
@@ -304,7 +304,9 @@ class AscEditor(BaseSchematic):
     def get_subcircuit(self, reference: str) -> 'AscEditor':
         """Returns an AscEditor file corresponding to the symbol"""
         sub = self.get_component(reference)
-        return sub.attributes['_SUBCKT']
+        if '_SUBCKT' in sub.attributes:
+            return sub.attributes['_SUBCKT']
+        raise AttributeError(f"An associated subcircuit was not found for {reference}")
 
     def get_component_info(self, reference) -> dict:
         """Returns the reference information as a dictionary"""

--- a/spicelib/editor/base_editor.py
+++ b/spicelib/editor/base_editor.py
@@ -478,6 +478,16 @@ class BaseEditor(ABC):
         :raises: ParameterNotFoundError - In case the component is not found
         """
         ...
+        
+    @abstractmethod
+    def get_all_parameter_names(self, param: str) -> str:
+        """
+        Returns all parameter names from the netlist.
+
+        :return: A list of parameter names found in the netlist
+        :rtype: List[str]
+        """
+        ...        
 
     def set_parameter(self, param: str, value: Union[str, int, float]) -> None:
         """Adds a parameter to the SPICE netlist.

--- a/spicelib/editor/qsch_editor.py
+++ b/spicelib/editor/qsch_editor.py
@@ -736,8 +736,8 @@ class QschEditor(BaseSchematic):
                     param_names.append(param_name.upper())
         return sorted(param_names)
 
-    def _qsch_file_find(self, filename: str, work_dir: str = '.') -> Optional[str]:
-        containers = [work_dir] + self.custom_lib_paths + self.simulator_lib_paths
+    def _qsch_file_find(self, filename) -> Optional[str]:
+        containers = ['.'] + self.custom_lib_paths + self.simulator_lib_paths
         # '.'  is the directory where the script is located
         return search_file_in_containers(filename, *containers)
 

--- a/spicelib/editor/qsch_editor.py
+++ b/spicelib/editor/qsch_editor.py
@@ -433,13 +433,12 @@ class QschEditor(BaseSchematic):
 
                 # schedule to write .SUBCKT clauses at the end
                 if model not in subcircuits_to_write:
-                    if '_SUBCKT' in component.attributes:
-                        pins = symbol_tag.get_items("pin")
-                        sub_ports = " ".join(pin.get_attr(QSCH_SYMBOL_PIN_NET) for pin in pins)
-                        subcircuits_to_write[model] = (
-                            component.attributes['_SUBCKT'],  # the subcircuit schematic is saved
-                            sub_ports,  # and also storing the port position now, so to save time later.
-                        )
+                    pins = symbol_tag.get_items("pin")
+                    sub_ports = " ".join(pin.get_attr(QSCH_SYMBOL_PIN_NET) for pin in pins)
+                    subcircuits_to_write[model] = (
+                        component.attributes['_SUBCKT'],  # the subcircuit schematic is saved
+                        sub_ports,  # and also storing the port position now, so to save time later.
+                    )
                 nets = " ".join(component.ports)
                 netlist_file.write(f'{refdes} {nets} {model}{parameters}\n')
 
@@ -667,13 +666,10 @@ class QschEditor(BaseSchematic):
             self.components[refdes] = sch_comp
             if refdes.startswith('X'):
                 sub_circuit_name = value + os.path.extsep + 'qsch'
-                mydir = self.circuit_file.parent.absolute().as_posix()
-                sub_circuit_schematic_file = self._qsch_file_find(sub_circuit_name, mydir)
+                sub_circuit_schematic_file = self._qsch_file_find(sub_circuit_name)
                 if sub_circuit_schematic_file:
                     sub_schematic = QschEditor(sub_circuit_schematic_file)
                     sch_comp.attributes['_SUBCKT'] = sub_schematic  # Store it for future use.
-                else:
-                    _logger.debug(f"Subcircuit {sub_circuit_name} not found")
 
         for text_tag in self.schematic.get_items('text'):
             x, y = text_tag.get_attr(QSCH_TEXT_POS)

--- a/spicelib/editor/qsch_editor.py
+++ b/spicelib/editor/qsch_editor.py
@@ -723,12 +723,7 @@ class QschEditor(BaseSchematic):
             return None, None
         
     def get_all_parameter_names(self) -> List[str]:
-        """
-        Returns all parameter names from the netlist.
-
-        :return: A list of parameter names found in the netlist
-        :rtype: List[str]
-        """
+        # docstring inherited from BaseEditor
         param_names = []
         param_regex = re.compile(PARAM_REGEX(r"\w+"), re.IGNORECASE)
         text_tags = self.schematic.get_items('text')

--- a/spicelib/editor/spice_editor.py
+++ b/spicelib/editor/spice_editor.py
@@ -394,6 +394,24 @@ class SpiceCircuit(BaseEditor):
             line_no += 1
         return -1, None  # If it fails, it returns an invalid line number and No match
 
+    def get_all_parameter_names(self) -> List[str]:
+        """
+        Returns all parameter names from the netlist.
+
+        :return: A list of parameter names found in the netlist
+        :rtype: List[str]
+        """
+        param_names = []
+        search_expression = re.compile(PARAM_REGEX(r"\w+"), re.IGNORECASE)
+        for line in self.netlist:
+            cmd = get_line_command(line)
+            if cmd == '.PARAM':
+                matches = search_expression.finditer(line)
+                for match in matches:
+                    param_name = match.group('name')
+                    param_names.append(param_name.upper())
+        return sorted(param_names)
+
     def get_subcircuit_names(self) -> List[str]:
         """
         Returns a list of the names of the sub-circuits in the netlist.

--- a/spicelib/editor/spice_editor.py
+++ b/spicelib/editor/spice_editor.py
@@ -395,12 +395,7 @@ class SpiceCircuit(BaseEditor):
         return -1, None  # If it fails, it returns an invalid line number and No match
 
     def get_all_parameter_names(self) -> List[str]:
-        """
-        Returns all parameter names from the netlist.
-
-        :return: A list of parameter names found in the netlist
-        :rtype: List[str]
-        """
+        # docstring inherited from BaseEditor
         param_names = []
         search_expression = re.compile(PARAM_REGEX(r"\w+"), re.IGNORECASE)
         for line in self.netlist:

--- a/unittests/test_asc_editor.py
+++ b/unittests/test_asc_editor.py
@@ -78,6 +78,7 @@ class ASC_Editor_Test(unittest.TestCase):
         self.equalFiles(temp_dir + 'test_components_output_1.asc', golden_dir + 'test_components_output_1.asc')
 
     def test_parameter_edit(self):
+        self.assertEqual(self.edt.get_all_parameter_names(), ['RES', 'TEMP'])
         self.assertEqual(self.edt.get_parameter('TEMP'), '0', "Tested TEMP Parameter")  # add assertion here
         self.edt.set_parameter('TEMP', 25)
         self.assertEqual(self.edt.get_parameter('TEMP'), '25', "Tested TEMP Parameter")  # add assertion here

--- a/unittests/test_qsch_editor.py
+++ b/unittests/test_qsch_editor.py
@@ -94,6 +94,7 @@ class ASC_Editor_Test(unittest.TestCase):
             self.assertEqual(r1_params[key], value, f"Tested R1 {key} Parameter")
 
     def test_parameter_edit(self):
+        self.assertEqual(self.edt.get_all_parameter_names(), ['RES', 'TEMP'])        
         self.assertEqual(self.edt.get_parameter('TEMP'), '0', "Tested TEMP Parameter")  # add assertion here
         self.edt.set_parameter('TEMP', 25)
         self.assertEqual(self.edt.get_parameter('TEMP'), '25', "Tested TEMP Parameter")  # add assertion here

--- a/unittests/test_spice_editor.py
+++ b/unittests/test_spice_editor.py
@@ -122,6 +122,7 @@ class SpiceEditor_Test(unittest.TestCase):
         self.equalFiles(temp_dir + 'opamptest_output_1.net', golden_dir + 'opamptest_output_1.net')
 
     def test_parameter_edit(self):
+        self.assertEqual(self.edt.get_all_parameter_names(), ['RES', 'TEMP'])
         self.assertEqual(self.edt.get_parameter('TEMP'), '0', "Tested TEMP Parameter")  # add assertion here
         self.edt.set_parameter('TEMP', 25)
         self.assertEqual(self.edt.get_parameter('TEMP'), '25', "Tested TEMP Parameter")  # add assertion here


### PR DESCRIPTION
Added `get_all_parameter_names()` to all editors.
Added unit tests.
.. and a small additional protection on `spicelib/editor/asc_editor.py:get_subcircuit` got snuck in.