### PR TITLE
corrected run_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ import zipfile
 import logging
 
 # In order for this, to work, you need to have a server running. To start a server, run the following command:
-# python -m spicelib.run_server --port 9000 --parallel 4 --output ./temp
+# python -m spicelib.scripts.run_server --port 9000 --parallel 4 --output ./temp LTSpice 300
 
 _logger = logging.getLogger("spicelib.SimClient")
 _logger.setLevel(logging.DEBUG)

--- a/doc/modules/client_server.rst
+++ b/doc/modules/client_server.rst
@@ -17,7 +17,7 @@ use the following command:
 
 .. code-block:: bash
 
-    python -m spicelib.run_server --port 9000 --parallel 4 --output ./temp
+    python -m spicelib.scripts.run_server --port 9000 --parallel 4 --output ./temp LTSpice 300
 
 Make sure that each machine is on the same network and that the port is open.
 If port is not specified, the default port is 9000.
@@ -32,7 +32,7 @@ On the client side, you can use the following code to run the simulation:
     import logging
 
     # In order for this, to work, you need to have a server running. To start a server, run the following command:
-    # python -m spicelib.run_server --port 9000 --parallel 4 --output ./temp
+    # python -m spicelib.scripts.run_server --port 9000 --parallel 4 --output ./temp LTSpice 300
 
     _logger = logging.getLogger("spicelib.SimClient")
     _logger.setLevel(logging.DEBUG)

--- a/examples/sim_client_example.py
+++ b/examples/sim_client_example.py
@@ -24,7 +24,7 @@ import zipfile
 import logging
 
 # In order for this, to work, you need to have a server running. To start a server, run the following command:
-# python -m spicelib.run_server --port 9000 --parallel 4 --output ./temp
+# python -m spicelib.scripts.run_server --port 9000 --parallel 4 --output ./temp LTSpice 300
 
 _logger = logging.getLogger("spicelib.SimClient")
 _logger.setLevel(logging.DEBUG)

--- a/spicelib/scripts/run_server.py
+++ b/spicelib/scripts/run_server.py
@@ -35,7 +35,7 @@ def main():
                     "SimClient class."
                     "The argument is the simulator to be used (LTSpice, NGSpice, XYCE, etc.)"
     )
-    parser.add_argument('simulator', type=str, nargs='?', default="LTSpice", choices=supported_sims,
+    parser.add_argument('simulator', type=str.lower, nargs='?', default="LTSpice", choices=supported_sims,
                         help="Simulator to be used (LTSpice, NGSpice, XYCE, etc.). Default is LTSpice")
     parser.add_argument("-p", "--port", type=int, default=9000,
                         help="Port to run the server. Default is 9000")

--- a/spicelib/scripts/run_server.py
+++ b/spicelib/scripts/run_server.py
@@ -26,6 +26,8 @@ import keyboard
 
 
 def main():
+    
+    supported_sims = ["LTSpice", "NGSpice", "Xyce"]
     parser = argparse.ArgumentParser(
         description="Run the LTSpice Server. This is a command line interface to the SimServer class."
                     "The SimServer class is used to run simulations in parallel using a server-client architecture."
@@ -33,18 +35,18 @@ def main():
                     "SimClient class."
                     "The argument is the simulator to be used (LTSpice, NGSpice, XYCE, etc.)"
     )
-    parser.add_argument('simulator', type=str, default="LTSpice",
-                        help="Simulator to be used (LTSpice, NGSpice, XYCE, etc.)")
+    parser.add_argument('simulator', type=str, nargs='?', default="LTSpice", choices=supported_sims,
+                        help="Simulator to be used (LTSpice, NGSpice, XYCE, etc.). Default is LTSpice")
     parser.add_argument("-p", "--port", type=int, default=9000,
                         help="Port to run the server. Default is 9000")
     parser.add_argument("-o", "--output", type=str, default=".",
                         help="Output folder for the results. Default is the current folder")
     parser.add_argument("-l", "--parallel", type=int, default=4,
                         help="Maximum number of parallel simulations. Default is 4")
-    parser.add_argument('timeout', type=int, default=300,
+    parser.add_argument('timeout', type=int, nargs='?', default=300,
                         help="Timeout for the simulations. Default is 300 seconds (5 minutes)")
 
-    if len(sys.argv) == 1:
+    if len(sys.argv) == 0:
         parser.print_help(sys.stderr)
         sys.exit(1)
 
@@ -52,20 +54,21 @@ def main():
     if args.parallel < 1:
         args.parallel = 1
 
-    if args.simulator == "LTSpice":
+    mysim = args.simulator.lower()
+    if mysim == "ltspice":
         from spicelib.simulators.ltspice_simulator import LTspice
         simulator = LTspice
-    elif args.simulator == "NGSpice":
+    elif mysim == "ngspice":
         from spicelib.simulators.ngspice_simulator import NGspiceSimulator
         simulator = NGspiceSimulator
-    elif args.simulator == "XYCE":
+    elif mysim == "xyce":
         from spicelib.simulators.xyce_simulator import XyceSimulator
         simulator = XyceSimulator
     else:
         raise ValueError(f"Simulator {args.simulator} is not supported")
         exit(-1)
 
-    print("Starting Server")
+    print(f"Starting {simulator.__name__} simulation server on port {args.port}.")
     server = SimServer(simulator, parallel_sims=args.parallel, output_folder=args.output,
                        port=args.port, timeout=args.timeout)
     print("Server Started. Press and hold 'q' to stop")

--- a/spicelib/scripts/run_server.py
+++ b/spicelib/scripts/run_server.py
@@ -35,7 +35,7 @@ def main():
                     "SimClient class."
                     "The argument is the simulator to be used (LTSpice, NGSpice, XYCE, etc.)"
     )
-    parser.add_argument('simulator', type=str.lower, nargs='?', default="LTSpice", choices=supported_sims,
+    parser.add_argument('simulator', type=str, nargs='?', default="ltspice", choices=supported_sims,
                         help="Simulator to be used (LTSpice, NGSpice, XYCE, etc.). Default is LTSpice")
     parser.add_argument("-p", "--port", type=int, default=9000,
                         help="Port to run the server. Default is 9000")
@@ -45,10 +45,6 @@ def main():
                         help="Maximum number of parallel simulations. Default is 4")
     parser.add_argument('timeout', type=int, nargs='?', default=300,
                         help="Timeout for the simulations. Default is 300 seconds (5 minutes)")
-
-    if len(sys.argv) == 0:
-        parser.print_help(sys.stderr)
-        sys.exit(1)
 
     args = parser.parse_args()
     if args.parallel < 1:

--- a/spicelib/scripts/run_server.py
+++ b/spicelib/scripts/run_server.py
@@ -27,7 +27,7 @@ import keyboard
 
 def main():
     
-    supported_sims = ["LTSpice", "NGSpice", "Xyce"]
+    supported_sims = ["ltspice", "ngspice", "xyce"]
     parser = argparse.ArgumentParser(
         description="Run the LTSpice Server. This is a command line interface to the SimServer class."
                     "The SimServer class is used to run simulations in parallel using a server-client architecture."

--- a/spicelib/simulators/xyce_simulator.py
+++ b/spicelib/simulators/xyce_simulator.py
@@ -67,7 +67,7 @@ class XyceSimulator(Simulator):
         process_name = None
     else:
         process_name = Simulator.guess_process_name(spice_exe[0])
-        _logger.debug(f"Found ngspice installed in: '{spice_exe}' ")
+        _logger.debug(f"Found xyce installed in: '{spice_exe}' ")
             
     xyce_args = {
         # '-b'                : ['-b'],  # batch mode flag for spice compatibility (ignored)


### PR DESCRIPTION
That was easy:
* corrected help texts
* improved command line handling of run_server
* found a small text error in xyce. Added that.

The `spicelib.scriptsrun_server:main` problem was probably already gone with poetry.

Small thing: `SimClient.add_sources()` is specified as returning a bool. But it returns nothing. 
