### PR TITLE
rawfile get trace with alias fails

### DIFF
--- a/spicelib/raw/raw_read.py
+++ b/spicelib/raw/raw_read.py
@@ -329,6 +329,8 @@ def consume16bytes(f):
 
 def namify(spice_ref: str):
     """Translate from V(0,n01) to V__n01__ and I(R1) to I__R1__"""
+    if spice_ref.lower() in ('time', 'frequency'):
+        return spice_ref
     matchobj = re.match(r'(V|I|P)\((\w+)\)', spice_ref)
     if matchobj:
         return f'{matchobj.group(1)}__{matchobj.group(2)}__'

--- a/unittests/test_rawreaders.py
+++ b/unittests/test_rawreaders.py
@@ -186,6 +186,13 @@ class RawReader_Test(unittest.TestCase):
                     self.assertAlmostEqual(abs(vout1), abs(h), 5, f"Difference between theoretical value and simulation at point {point}")
                     self.assertAlmostEqual(angle(vout1), angle(h), 5, f"Difference between theoretical value and simulation at point {point}")
 
+                # see if we can read alias traces as well
+                test_name = "i(r1)"
+                if test_name in (name.lower() for name in raw.get_trace_names()):
+                    tracelen = len(raw.get_trace(test_name).data)
+                    print(f"tracelen, alt: {tracelen}")
+                    self.assertEqual(tracelen, testset[simulator]["ac"]["expected_tracelen"], "Not the expected number of points for alternative trace")
+                    
     def test_rawreaders_tran(self):
         for simulator in testset:
             dialect = None
@@ -240,6 +247,17 @@ class RawReader_Test(unittest.TestCase):
                     vout = vin * (1 - exp(-1 * tm / (R1 * C1))) 
                     # print(f"testing pt {point} for time {tm}: vin={vin}, vout_sim={vout1}, vout_th={vout}")
                     self.assertAlmostEqual(abs(vout1), vout, 3, f"Difference between theoretical value and simulation at point {point}")
+
+                # see if we can read alias traces as well
+                test_name = "i(r1)"
+                if test_name in (name.lower() for name in raw.get_trace_names()):
+                    tracelen = len(raw.get_trace(test_name).data)
+                    print(f"tracelen, alt: {tracelen}")
+                    expected_tracelen = testset[simulator]["tran"]["expected_tracelen"]
+                    if isinstance(expected_tracelen, int):
+                        self.assertEqual(tracelen, expected_tracelen, "Not the expected number of points for alternative trace")
+                    else:
+                        self.assertEqual(tracelen, expected_tracelen[fileno], "Not the expected number of points for alternative trace")
 
                 fileno += 1
                 


### PR DESCRIPTION
Whenever a `rawread.get_trace()` is requested on an alias, it risks failing because 'time' and 'frequency' are unknown to `namify()`. I imagine this used to work at one point in time. 

Corrected, but could probably be done in a more robust way. 

Anyway, unit test was added. No matter the implementation, it now checks on correct working of get_trace on an alias.