### PR TITLE
184 qspice editor remove instruction and remove xinstruction also remove comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,7 +937,7 @@ in [GitHub spicelib issues](https://github.com/nunobrum/spicelib/issues)
 
 * future version
     * Fixed Issue #177 and #181 - get_trace fails when trace is alias and engineering notation is used
-    * Fixed Issue #178 - ignore Qspice parameters that are comments
+    * Fixed Issue #184 and #178 - improve handling of comments
 * Version 1.4.2
     * SimRunner runno, okSim and failSim are now readonly attributes
     * SimStepper now stores all netlist updates. This information can now be exported to a CSV file.

--- a/examples/testfiles/comment_test.asc
+++ b/examples/testfiles/comment_test.asc
@@ -1,0 +1,10 @@
+Version 4
+SHEET 1 880 680
+TEXT 0 0 Left 2 ;.tran 0 1m 0 100n uic
+TEXT 0 100 Left 2 ;.model D D(Ron=1m Roff=1Meg Vfwd=0.8)
+TEXT 0 200 Left 2 ;.param R = 100
+TEXT 0 300 Left 2 ;.option SavePowers
+TEXT 0 400 Left 2 !.ac 30 10 1Meg
+TEXT 0 500 Left 2 !.model D D(Ron=10m Roff=10Meg Vfwd=0.8)
+TEXT 0 600 Left 2 !.param R = 1k
+TEXT 0 700 Left 2 !.option SavePowers

--- a/examples/testfiles/comment_test.qsch
+++ b/examples/testfiles/comment_test.qsch
@@ -1,0 +1,11 @@
+ÿØÿÛ«schematic
+  «text (0,0) 1 7 1 0x1000000 -1 -1 "ï»¿.tran 0 1m 0 100n uic"»
+  «text (0,100) 1 7 1 0x1000000 -1 -1 "ï»¿.model D D(Ron=1m Roff=1Meg Vfwd=0.8)"»
+  «text (0,200) 1 7 1 0x1000000 -1 -1 "ï»¿.param R = 100"»
+  «text (0,300) 1 7 1 0x1000000 -1 -1 "ï»¿.option SavePowers"»
+  «text (0,400) 1 7 0 0x1000000 -1 -1 "ï»¿.ac 30 10 1Meg"»
+  «text (0,500) 1 7 0 0x1000000 -1 -1 "ï»¿.model D D(Ron=10m Roff=10Meg Vfwd=0.8)"»
+  «text (0,600) 1 7 0 0x1000000 -1 -1 "ï»¿.param R = 1k"»
+  «text (0,700) 1 7 0 0x1000000 -1 -1 "ï»¿.option SavePowers"»
+»
+

--- a/spicelib/editor/asc_editor.py
+++ b/spicelib/editor/asc_editor.py
@@ -650,6 +650,9 @@ class AscEditor(BaseSchematic):
         i = 0
         while i < len(self.directives):
             if instruction in self.directives[i].text:
+                if instruction.type == TextTypeEnum.COMMENT:
+                    i += 1
+                    continue  # this is a comment                       
                 text = self.directives[i].text
                 del self.directives[i]
                 _logger.info(f"Instruction {text} removed")
@@ -667,6 +670,9 @@ class AscEditor(BaseSchematic):
         i = 0
         while i < len(self.directives):
             instruction = self.directives[i].text
+            if instruction.type == TextTypeEnum.COMMENT:
+                i += 1
+                continue  # this is a comment            
             if regex.match(instruction) is not None:
                 instr_removed = True
                 del self.directives[i]

--- a/spicelib/editor/asc_editor.py
+++ b/spicelib/editor/asc_editor.py
@@ -328,6 +328,8 @@ class AscEditor(BaseSchematic):
         param_name_uppercase = param_name.upper()
         search_expression = re.compile(PARAM_REGEX(r"\w+"), re.IGNORECASE)
         for directive in self.directives:
+            if directive.type == TextTypeEnum.COMMENT:
+                continue  # this is a comment, skip it            
             if directive.text.upper().startswith(".PARAM"):
                 matches = search_expression.finditer(directive.text)
                 for match in matches:
@@ -340,6 +342,8 @@ class AscEditor(BaseSchematic):
         param_names = []
         search_expression = re.compile(PARAM_REGEX(r"\w+"), re.IGNORECASE)
         for directive in self.directives:
+            if directive.type == TextTypeEnum.COMMENT:
+                continue  # this is a comment, skip it
             if directive.text.upper().startswith(".PARAM"):
                 matches = search_expression.finditer(directive.text)
                 for match in matches:            
@@ -633,7 +637,7 @@ class AscEditor(BaseSchematic):
                     continue  # this is a comment
                 directive_command = directive.text.split()[0].upper()
                 if directive_command in UNIQUE_SIMULATION_DOT_INSTRUCTIONS:
-                    directive.text = instruction
+                    self.directives[i].text = instruction
                     self.updated = True
                     return  # Job done, can exit this method
                 i += 1
@@ -649,10 +653,10 @@ class AscEditor(BaseSchematic):
     def remove_instruction(self, instruction: str) -> None:
         i = 0
         while i < len(self.directives):
-            if instruction in self.directives[i].text:
-                if self.directives[i].type == TextTypeEnum.COMMENT:
-                    i += 1
-                    continue  # this is a comment                       
+            if self.directives[i].type == TextTypeEnum.COMMENT:
+                i += 1
+                continue  # this is a comment   
+            if instruction in self.directives[i].text:                    
                 text = self.directives[i].text
                 del self.directives[i]
                 _logger.info(f"Instruction {text} removed")
@@ -669,10 +673,10 @@ class AscEditor(BaseSchematic):
         instr_removed = False
         i = 0
         while i < len(self.directives):
-            instruction = self.directives[i].text
             if self.directives[i].type == TextTypeEnum.COMMENT:
                 i += 1
                 continue  # this is a comment            
+            instruction = self.directives[i].text
             if regex.match(instruction) is not None:
                 instr_removed = True
                 del self.directives[i]

--- a/spicelib/editor/asc_editor.py
+++ b/spicelib/editor/asc_editor.py
@@ -79,9 +79,20 @@ class AscEditor(BaseSchematic):
         return self.asc_file_path
 
     def save_netlist(self, run_netlist_file: Union[str, Path]) -> None:
+        """
+        Saves the current state of the netlist to a .asc file. 
+        For writing to a .net or .cir file, use the `LTspice.create_netlist()` method instead.
+
+        :param run_netlist_file: File name of the netlist file.
+        :type run_netlist_file: Path or str
+        :returns: Nothing
+        """        
         if isinstance(run_netlist_file, str):
             run_netlist_file = Path(run_netlist_file)
-        run_netlist_file = run_netlist_file.with_suffix(".asc")
+        if run_netlist_file.suffix in ('.net', '.cir'):
+            raise ValueError("Use the `LTspice.create_netlist()` method instead")
+        if run_netlist_file.suffix != '.asc':
+            run_netlist_file = run_netlist_file.with_suffix(".asc")
         with open(run_netlist_file, 'w', encoding=self.encoding) as asc:
             _logger.info(f"Writing ASC file {run_netlist_file}")
 

--- a/spicelib/editor/asc_editor.py
+++ b/spicelib/editor/asc_editor.py
@@ -650,7 +650,7 @@ class AscEditor(BaseSchematic):
         i = 0
         while i < len(self.directives):
             if instruction in self.directives[i].text:
-                if instruction.type == TextTypeEnum.COMMENT:
+                if self.directives[i].type == TextTypeEnum.COMMENT:
                     i += 1
                     continue  # this is a comment                       
                 text = self.directives[i].text
@@ -670,7 +670,7 @@ class AscEditor(BaseSchematic):
         i = 0
         while i < len(self.directives):
             instruction = self.directives[i].text
-            if instruction.type == TextTypeEnum.COMMENT:
+            if self.directives[i].type == TextTypeEnum.COMMENT:
                 i += 1
                 continue  # this is a comment            
             if regex.match(instruction) is not None:

--- a/spicelib/editor/base_editor.py
+++ b/spicelib/editor/base_editor.py
@@ -765,7 +765,7 @@ class BaseEditor(ABC):
         ...
 
     @abstractmethod
-    def remove_instruction(self, instruction) -> None:
+    def remove_instruction(self, instruction: str) -> None:
         """
         Removes a SPICE instruction from the netlist.
 
@@ -796,9 +796,9 @@ class BaseEditor(ABC):
 
         .. code-block:: python
 
-            editor.remove_Xinstruction("\\.AC.*")
+            editor.remove_Xinstruction(r"\\.AC.*")
 
-        :param search_pattern: The list of instructions to remove. Each instruction is of the type 'str'
+        :param search_pattern: The list of instructions to remove. Each instruction is of the type 'str'. In general it is best to use a raw string (r).
         :type search_pattern: str
         :returns: Nothing
         """

--- a/spicelib/editor/qsch_editor.py
+++ b/spicelib/editor/qsch_editor.py
@@ -533,6 +533,13 @@ class QschEditor(BaseSchematic):
         # Note: the .END or .ENDCKT must be inserted by the calling function
 
     def save_netlist(self, run_netlist_file: Union[str, Path]) -> None:
+        """
+        Saves the current state of the netlist to a .qsh or to a .net or .cir file.
+
+        :param run_netlist_file: File name of the netlist file. Can be .qsch, .net or .cir
+        :type run_netlist_file: Path or str
+        :returns: Nothing
+        """        
         if isinstance(run_netlist_file, str):
             run_netlist_file = Path(run_netlist_file)
 

--- a/spicelib/editor/qsch_editor.py
+++ b/spicelib/editor/qsch_editor.py
@@ -1048,6 +1048,8 @@ class QschEditor(BaseSchematic):
     def remove_instruction(self, instruction: str) -> None:
         # docstring inherited from BaseEditor
         for text_tag in self.schematic.get_items('text'):
+            if text_tag.get_attr(QSCH_TEXT_COMMENT) == 1:  # if it is a comment, we ignore it
+                continue            
             text = text_tag.get_attr(QSCH_TEXT_STR_ATTR)
             if instruction in text:
                 self.schematic.items.remove(text_tag)
@@ -1062,6 +1064,8 @@ class QschEditor(BaseSchematic):
         regex = re.compile(search_pattern, re.IGNORECASE)
         instr_removed = False
         for text_tag in self.schematic.get_items('text'):
+            if text_tag.get_attr(QSCH_TEXT_COMMENT) == 1:  # if it is a comment, we ignore it
+                continue            
             text = text_tag.get_attr(QSCH_TEXT_STR_ATTR)
             text = text.lstrip(QSCH_TEXT_INSTR_QUALIFIER)
             if regex.match(text):

--- a/spicelib/sim/sim_stepping.py
+++ b/spicelib/sim/sim_stepping.py
@@ -108,7 +108,7 @@ class SimStepper(AnyRunner):
         self.netlist.remove_instruction(instruction)
 
     @wraps(BaseEditor.remove_Xinstruction)
-    def remove_Xinstruction(self, search_pattern) -> None:
+    def remove_Xinstruction(self, search_pattern: str) -> None:
         self.netlist.remove_Xinstruction(search_pattern)
 
     @wraps(BaseEditor.set_parameters)

--- a/unittests/golden/comment_test.asc
+++ b/unittests/golden/comment_test.asc
@@ -1,0 +1,9 @@
+Version 4
+SHEET 1 880 680
+TEXT 0 0 Left 2 ;.tran 0 1m 0 100n uic
+TEXT 0 100 Left 2 ;.model D D(Ron=1m Roff=1Meg Vfwd=0.8)
+TEXT 0 200 Left 2 ;.param R = 100
+TEXT 0 300 Left 2 ;.option SavePowers
+TEXT 0 400 Left 2 !.ac test
+TEXT 0 600 Left 2 !.param R = 1Meg
+TEXT 0 724 Left 2 !.option blabla

--- a/unittests/golden/comment_test.qsch
+++ b/unittests/golden/comment_test.qsch
@@ -1,0 +1,10 @@
+ÿØÿÛ«schematic
+  «text (0,0) 1 7 1 0x1000000 -1 -1 "ï»¿.tran 0 1m 0 100n uic"»
+  «text (0,100) 1 7 1 0x1000000 -1 -1 "ï»¿.model D D(Ron=1m Roff=1Meg Vfwd=0.8)"»
+  «text (0,200) 1 7 1 0x1000000 -1 -1 "ï»¿.param R = 100"»
+  «text (0,300) 1 7 1 0x1000000 -1 -1 "ï»¿.option SavePowers"»
+  «text (0,400) 1 7 0 0x1000000 -1 -1 "ï»¿.ac test"»
+  «text (0,600) 1 7 0 0x1000000 -1 -1 "ï»¿.param R = 1Meg"»
+  «text (0,-240) 1 0 0 0x1000000 -1 -1 "ï»¿.option blabla"»
+»
+

--- a/unittests/test_asc_editor.py
+++ b/unittests/test_asc_editor.py
@@ -216,6 +216,20 @@ class ASC_Editor_Test(unittest.TestCase):
         """Test file with 'Version 4.1'
         """
         my_edt = spicelib.editor.asc_editor.AscEditor(test_dir + "testcomp_4_1.asc")
+        
+    def test_comments(self):
+        myfile = "comment_test.asc"
+        my_edt = spicelib.editor.asc_editor.AscEditor(test_dir + myfile)
+
+        self.assertEqual(my_edt.get_all_parameter_names(), ["R"])
+        my_edt.add_instruction(".ac test")  # OK
+        my_edt.add_instruction(".option blabla")  # OK
+        my_edt.remove_instruction(".option SavePowers")  # OK
+        my_edt.remove_Xinstruction(r"\.model.*")  # OK
+        my_edt.set_parameter("R", 1e6)  # OK
+        
+        my_edt.save_netlist(temp_dir + myfile)
+        self.equalFiles(temp_dir + myfile, golden_dir + myfile)
                 
     def equalFiles(self, file1, file2):
         with open(file1, 'r') as f1:

--- a/unittests/test_qsch_editor.py
+++ b/unittests/test_qsch_editor.py
@@ -131,6 +131,21 @@ class ASC_Editor_Test(unittest.TestCase):
         equalFiles(self, temp_dir + 'test_instructions_output_2.qsch', golden_dir + 'test_instructions_output_2.qsch')
         self.edt.save_netlist(temp_dir + 'test_instructions_output_qsch_2.net')
         equalFiles(self, temp_dir + 'test_instructions_output_qsch_2.net', golden_dir + 'test_instructions_output_qsch_2.net')
+        
+    def test_comments(self):
+        myfile = "comment_test.qsch"
+        my_edt = spicelib.editor.qsch_editor.QschEditor(test_dir + myfile)
+
+        self.assertEqual(my_edt.get_all_parameter_names(), ["R"])
+        my_edt.add_instruction(".ac test")  # OK
+        my_edt.add_instruction(".option blabla")  # OK
+        my_edt.remove_instruction(".option SavePowers")  # OK
+        my_edt.remove_Xinstruction(r"\.model.*")  # OK
+        my_edt.set_parameter("R", 1e6)  # OK
+        
+        my_edt.save_netlist(temp_dir + myfile)
+        equalFiles(self, temp_dir + myfile, golden_dir + myfile)
+
 
 class QschEditorRotation(unittest.TestCase):
 


### PR DESCRIPTION
1) Improved handling of comment, extension of #178, with unit tests. This covers both asc editor and qsch editor. netlist editor is not affected.

2) Also added a small documentation change to `save_netlist` of both editors, as there were recurring questions about that, and there is a discrepancy between the 2 editors.

3) Line 636 in asc_editor looks like a bug. So repaired that.
```python
                    directive.text = instruction
```
and `directive` was not saved before the return. So: 
```python
                    self.directives[i].text = instruction
```