### PR TITLE
186 asc alignment is case sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,6 +936,7 @@ in [GitHub spicelib issues](https://github.com/nunobrum/spicelib/issues)
 ## History
 
 * future version
+    * Fixed Issue #186 - Allow VerAlign in AsyReader, and make alignment case insensitive
     * Fixed Issue #177 and #181 - get_trace fails when trace is alias and engineering notation is used
     * Fixed Issue #178 - ignore Qspice parameters that are comments
 * Version 1.4.2

--- a/spicelib/editor/asy_reader.py
+++ b/spicelib/editor/asy_reader.py
@@ -162,11 +162,14 @@ class AsyReader(object):
                     if len(line_elements) == 6:
                         x = int(line_elements[1])
                         y = int(line_elements[2])
+                        alignment = line_elements[3]
 
-                        text = Text(Point(x, y), text=line_elements[5], size=int(line_elements[4]),
+                        text = Text(Point(x, y), 
+                                    text=line_elements[5], 
+                                    size=int(line_elements[4]),
                                     type=TextTypeEnum.COMMENT,
-                                    textAlignment=HorAlign(line_elements[3]),
                                     )
+                        text = asc_text_align_set(text, alignment)
                         self.windows.append(text)
                     else:
                         # Text in asy not supported however non-critical and not neccesary to crash the program.

--- a/spicelib/editor/ltspice_utils.py
+++ b/spicelib/editor/ltspice_utils.py
@@ -71,22 +71,23 @@ def asc_text_align_set(text: Text, alignment: str):
     # Default
     text.textAlignment = HorAlign.CENTER
     text.verticalAlignment = VerAlign.CENTER
-    if alignment == 'Left' or alignment == 'VLeft':
+    alignment = alignment.lower()
+    if alignment == 'left' or alignment == 'vleft':
         text.textAlignment = HorAlign.LEFT
-    elif alignment == 'Center' or alignment == 'VCenter':
+    elif alignment == 'center' or alignment == 'vcenter':
         pass
-    elif alignment == 'Right' or alignment == 'VRight':
+    elif alignment == 'right' or alignment == 'vright':
         text.textAlignment = HorAlign.RIGHT
-    elif alignment == 'Top' or alignment == 'VTop':
+    elif alignment == 'top' or alignment == 'vtop':
         text.verticalAlignment = VerAlign.TOP
-    elif alignment == 'Bottom' or alignment == 'VBottom':
+    elif alignment == 'bottom' or alignment == 'vbottom':
         text.verticalAlignment = VerAlign.BOTTOM
-    elif alignment == 'Invisible' or alignment == 'VInvisible':
+    elif alignment == 'invisible' or alignment == 'vinvisible':
         text.visible = False
     else:
         raise ValueError(f"Invalid alignment {alignment}")
 
-    if alignment.startswith('V'):
+    if alignment.startswith('v'):
         text.angle = ERotation.R90
     else:
         text.angle = ERotation.R0


### PR DESCRIPTION
Easy one: 
* use `asc_text_align_set` in asyreader instead of directly HorAlign. It was the only case in the code base where this happened.
* make alignment case insensitive. There are some .asy files where they mix case.

This is so small, would it need a unit test?