### PR TITLE
Remove code specific for Python 3.5 and older

### DIFF
--- a/spicelib/sim/run_task.py
+++ b/spicelib/sim/run_task.py
@@ -25,25 +25,18 @@ __author__ = "Nuno Canto Brum <nuno.brum@gmail.com>"
 __copyright__ = "Copyright 2023, Fribourg Switzerland"
 
 from pathlib import Path
-import sys
 import threading
 import time
 import traceback
 from time import sleep
 from typing import Callable, Union, Any, Tuple, Type
 import logging
-import subprocess
 _logger = logging.getLogger("spicelib.RunTask")
 
 from .process_callback import ProcessCallback
 from .simulator import Simulator
 
 END_LINE_TERM = '\n'
-
-if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
-    clock_function = time.time
-else:
-    clock_function = time.clock
 
 
 def format_time_difference(time_diff):
@@ -97,12 +90,12 @@ class RunTask(threading.Thread):
     def run(self):
         # Running the Simulation
 
-        self.start_time = clock_function()
+        self.start_time = time.time()
         self.print_info(_logger.info, ": Starting simulation %d: %s" % (self.runno, self.netlist_file))
         # start execution
         self.retcode = self.simulator.run(self.netlist_file.absolute().as_posix(), self.switches, self.timeout,
                                           exe_log=self.exe_log)
-        self.stop_time = clock_function()
+        self.stop_time = time.time()
         # print simulation time with format HH:MM:SS.mmmmmm
 
         # Calculate the time difference
@@ -142,7 +135,7 @@ class RunTask(threading.Thread):
                             self.callback_return = return_or_process
                     finally:
                         callback_start_time = self.stop_time
-                        self.stop_time = clock_function()
+                        self.stop_time = time.time()
                         self.print_info(_logger.info, "Callback Finished. Time elapsed: %s" % format_time_difference(
                             self.stop_time - callback_start_time))
                 else:

--- a/spicelib/sim/simulator.py
+++ b/spicelib/sim/simulator.py
@@ -31,20 +31,11 @@ import shlex
 
 _logger = logging.getLogger("spicelib.Simulator")
 
-if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
-    def run_function(command, timeout=None, stdout=None, stderr=None):
-        """Normalizing OS subprocess function calls between different platforms. This function is used for python 3.6
-        and higher versions."""
-        _logger.debug(f"Running command: {command}, with timeout: {timeout}")
-        result = subprocess.run(command, timeout=timeout, stdout=stdout, stderr=stderr)
-        return result.returncode
-
-else:
-    def run_function(command, timeout=None, stdout=None, stderr=None):
-        """Normalizing OS subprocess function calls between different platforms. This is the old function that was used
-        for python version prior to 3.6"""
-        _logger.debug(f"Running command: {command}, with timeout: {timeout}")
-        return subprocess.call(command, timeout=timeout, stdout=stdout, stderr=stderr)
+def run_function(command, timeout=None, stdout=None, stderr=None):
+    """Normalizing OS subprocess function calls between different platforms."""
+    _logger.debug(f"Running command: {command}, with timeout: {timeout}")
+    result = subprocess.run(command, timeout=timeout, stdout=stdout, stderr=stderr)
+    return result.returncode
 
 
 class SpiceSimulatorError(Exception):


### PR DESCRIPTION
Found some dead Python code while looking into something else.  spicelib now explicitly supports only Python 3.9+ so I believe this code can be safely removed.