### PR TITLE
[noissue] Fix `SpiceEditor.set_component_parameters` not being able to set parameters to inductances

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,6 +941,8 @@ in [GitHub spicelib issues](https://github.com/nunobrum/spicelib/issues)
 
 ## History
 
+* Next release
+    * Fix addition of parameters (e.g. `ic`) to Inductances via `SpiceEditor.set_component_parameters` - PR #197
 * Version 1.4.3
     * Fixed Issue #188 - remove_(X)instruction now returns a boolean
     * Fixed Issue #186 - Allow VerAlign in AsyReader, and make alignment case insensitive

--- a/spicelib/editor/spice_editor.py
+++ b/spicelib/editor/spice_editor.py
@@ -44,7 +44,7 @@ END_LINE_TERM = '\n'  #: This controls the end of line terminator used
 FLOAT_RGX = r"[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?"
 
 # Regular expression for a number with decimal qualifier and unit
-NUMBER_RGX = r"[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?(Meg|[kmuµnpfgt])?[a-zA-Z]*"
+NUMBER_RGX = FLOAT_RGX + r"(Meg|[kmuµnpfgt])?[a-zA-Z]*"
 
 # Parameters expression of the type: PARAM=value
 PARAM_RGX = r"(?P<params>(\s+\w+\s*(=\s*[\w\{\}\(\)\-\+\*\/%\.]+)?)*)?"

--- a/spicelib/editor/spice_editor.py
+++ b/spicelib/editor/spice_editor.py
@@ -77,7 +77,9 @@ REPLACE_REGEXS = {
     'J': r"^(?P<designator>J§?\w+)(?P<nodes>(\s+\S+){3})\s+(?P<value>\w+)" + 
          PARAM_RGX + ".*?$",  # JFET
     'K': r"^(?P<designator>K§?\w+)(?P<nodes>(\s+\S+){2,4})\s+(?P<value>[\+\-]?[0-9\.E+-]+[kmuµnpgt]?).*$",  # Mutual Inductance
-    'L': r"^(?P<designator>L§?\w+)(?P<nodes>(\s+\S+){2})\s+(?P<value>({)?(?(5).*}|([0-9\.E+-]+(Meg|[kmuµnpgt])?H?))).*$",  # Inductance
+    'L': r"^(?P<designator>L§?\w+)(?P<nodes>(\s+\S+){2})(?P<model>\s+\w+)?\s+"
+         + VALUE_RGX(FLOAT_RGX + r"(Meg|[kmuµnpgt]?)H?") 
+         + PARAM_RGX + r".*?$",  # Inductance
     'M': r"^(?P<designator>M§?\w+)(?P<nodes>(\s+\S+){3,4})\s+(?P<value>\w+)" + PARAM_RGX + ".*?$",  # MOSFET
     'O': r"^(?P<designator>O§?\w+)(?P<nodes>(\s+\S+){4})\s+(?P<value>\w+)" + PARAM_RGX + ".*?$",  # Lossy Transmission Line
     'Q': r"^(?P<designator>Q§?\w+)(?P<nodes>(\s+\S+){3,4})\s+(?P<value>\w+)" + PARAM_RGX + ".*?$",  # Bipolar


### PR DESCRIPTION
I'm a user of PyLTSpice 5.4.2, with spicelib 1.4.3, on Windows 10.

I've tried to set initial conditions in both capacitors and inductances, but in the latter it does not seem to work. I've tracked down the issue to a mismatch between the regexes used in spice_editor.py . This PR fixes it by using the capacitor regex as a template and keeping the inductance-specific details.

Here is code and an .asc file to replicate the problem, you would need to trim the .txt filename extension, cause GH doesn't like .asc nor .net files.

```python
# %%
from PyLTSpice import SpiceEditor
from PyLTSpice import LTspice
from PyLTSpice import SimRunner

asc_file = "ic_test.asc"
netlist_file = asc_file.rstrip(".asc") + ".net"
# load .asc and translate to netlist
simulator = SimRunner(output_folder="./simulation_output", simulator=LTspice)
simulator.create_netlist(
    asc_file=asc_file
)  # creates netlist file with same filename, .net file extension

# load netlist file for editing
editor = SpiceEditor(netlist_file=netlist_file)
# try to set initial conditions for capacitor
editor.set_component_parameters("C1", ic=0.5)
# try to set initial conditions for inductor
editor.set_component_parameters("L1", ic=0.5)
``` 
[ic_test.asc.txt](https://github.com/user-attachments/files/19592382/ic_test.asc.txt)
[ic_test.net.txt](https://github.com/user-attachments/files/19592388/ic_test.net.txt)
