### PR TITLE
Resolving symbol file paths for LTspice in wine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1007,6 +1007,7 @@ in [GitHub spicelib issues](https://github.com/nunobrum/spicelib/issues)
 ## History
 
 * Next release
+    * Fixed Issue #207 - Resolving symbol file paths for LTspice in wine
     * Fixed Issues #197 and #198 - Improved support for many elements, documented limitations
     * Fixed Issue #192 - add information about timeouts and other exceptions to runner
 * Version 1.4.3

--- a/spicelib/editor/asc_editor.py
+++ b/spicelib/editor/asc_editor.py
@@ -17,6 +17,7 @@
 # Licence:     refer to the LICENSE file
 # -------------------------------------------------------------------------------
 import os.path
+import sys
 from pathlib import Path
 from typing import Union, Optional, Tuple, List
 from ..utils.detect_encoding import detect_encoding, EncodingDetectError
@@ -271,6 +272,14 @@ class AscEditor(BaseSchematic):
 
     def _get_symbol(self, symbol: str) -> AsyReader:
         asy_filename = symbol + os.path.extsep + "asy"
+        
+        if sys.platform == "linux" or sys.platform == "darwin":
+            if '\\' in asy_filename:
+                # This is a Windows path, so we need to remove the backslashes for non-Windows use
+                asy_filename = asy_filename.replace('\\', '/')
+                # and sometimes you have more than one
+                asy_filename = asy_filename.replace('//', '/')
+         
         asy_path = self._asy_file_find(asy_filename)
         if asy_path is None:
             raise FileNotFoundError(f"File {asy_filename} not found")


### PR DESCRIPTION
Searched a bit, found no other cases like this in the code.

Setting up a unittest would be extremely complicated for this.