### PR TITLE
run_server.py: linux compatibility and allow setting of IP address to bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,7 @@ in [GitHub spicelib issues](https://github.com/nunobrum/spicelib/issues)
 ## History
 
 * Version 1.4.5
+    * Fixing Issue #233 and #234 - `run_server` enhancements and platform compatibility
     * Fixing Issue #224 - Allow maintenance of `.control` sections
     * Fixing Issue #219 - Provide an option for defining the directory in which spice is executed
     * Fixing Issue #218 - Allow reading of multiple plots from 1 raw file

--- a/README.md
+++ b/README.md
@@ -968,21 +968,24 @@ server.close_session()
 -- in examples/sim_client_example.py [SimClient Example]
 
 ```text
-usage: run_server [-h] [-p PORT] [-o OUTPUT] [-l PARALLEL] simulator
+usage: run_server.py [-h] [-p PORT] [-H HOST] [-o OUTPUT] [-l PARALLEL] [{ltspice,ngspice,xyce}] [timeout]
 
-Run the LTSpice Server. This is a command line interface to the SimServer class. The SimServer class is used to run
-simulations in parallel using a server-client architecture. The server is a machine that runs the SimServer class and
-the client is a machine that runs the SimClient class. The argument is the simulator to be used (LTSpice, Ngspice, XYCE, etc.)
+Run the LTSpice Server. This is a command line interface to the SimServer class.The SimServer class is used to run simulations in parallel using a
+server-client architecture.The server is a machine that runs the SimServer class and the client is a machine that runs the SimClient class.The
+argument is the simulator to be used (LTSpice, NGSpice, XYCE, etc.)
 
 positional arguments:
-  simulator             Simulator to be used (LTSpice, Ngspice, XYCE, etc.)
+  {ltspice,ngspice,xyce}
+                        Simulator to be used (LTSpice, NGSpice, XYCE, etc.). Default is LTSpice
+  timeout               Timeout for the simulations. Default is 300 seconds (5 minutes)
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
-  -p PORT, --port PORT  Port to run the server. Default is 9000
-  -o OUTPUT, --output OUTPUT
-                        Output folder for the results. Default is the current folder
-  -l PARALLEL, --parallel PARALLEL
+  -p, --port PORT       Port to run the server. Default is 9000
+  -H, --host HOST       The IP address where the server will listen for requests. Default is 'localhost', which might mean that the server will only
+                        accept requests from the local machine
+  -o, --output OUTPUT   Output folder for the results. Default is the current folder
+  -l, --parallel PARALLEL
                         Maximum number of parallel simulations. Default is 4
 ```
 

--- a/README.md
+++ b/README.md
@@ -958,8 +958,10 @@ for runid in server:  # Ma
     zip_filename = server.get_runno_data(runid)
     print(f"Received {zip_filename} from runid {runid}")
     with zipfile.ZipFile(zip_filename, 'r') as zipf:  # Extract the contents of the zip file
-        print(zipf.namelist())  # Debug printing the contents of the zip file
-        zipf.extract(zipf.namelist()[0])  # Normally the raw file comes first
+        # print(zipf.namelist())  # Debug printing the contents of the zip file
+        for name in zipf.namelist():
+            print(f"Extracting {name} from {zip_filename}")
+            zipf.extract(name)
     os.remove(zip_filename)  # Remove the zip file
 
 server.close_session()

--- a/examples/sim_client_example.py
+++ b/examples/sim_client_example.py
@@ -39,8 +39,10 @@ for runid in server:  # Ma
     zip_filename = server.get_runno_data(runid)
     print(f"Received {zip_filename} from runid {runid}")
     with zipfile.ZipFile(zip_filename, 'r') as zipf:  # Extract the contents of the zip file
-        print(zipf.namelist())  # Debug printing the contents of the zip file
-        zipf.extract(zipf.namelist()[0])  # Normally the raw file comes first
+        # print(zipf.namelist())  # Debug printing the contents of the zip file
+        for name in zipf.namelist():
+            print(f"Extracting {name} from {zip_filename}")
+            zipf.extract(name)
     os.remove(zip_filename)  # Remove the zip file
 
 server.close_session()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ numpy = "*"
 scipy = "*"
 psutil = "*"
 matplotlib = "*"
-keyboard = "*"
 
 [tool.poetry.scripts]
 ltsteps = "spicelib.scripts.ltsteps:main"

--- a/spicelib/client_server/sim_server.py
+++ b/spicelib/client_server/sim_server.py
@@ -21,7 +21,6 @@
 from xmlrpc.client import Binary
 from xmlrpc.server import SimpleXMLRPCServer
 import logging
-_logger = logging.getLogger("spicelib.SimServer")
 
 import threading
 from pathlib import Path
@@ -29,6 +28,8 @@ import zipfile
 import io
 from spicelib.client_server.srv_sim_runner import ServerSimRunner
 import uuid
+
+_logger = logging.getLogger("spicelib.SimServer")
 
 
 class SimServer(object):
@@ -43,10 +44,19 @@ class SimServer(object):
     The server can be stopped by the client by calling the stop_server method.
 
     :param simulator: The simulator to be used. It must be a class that derives from the BaseSimulator class.
+    :type simulator: class
     :param parallel_sims: The maximum number of parallel simulations that the server can run. Default is 4.
+    :type parallel_sims: int
     :param output_folder: The folder where the results of the simulations will be stored. Default is './temp'
+    :type output_folder: str
     :param timeout: The maximum time that a simulation can run. Default is None, which means that there is no timeout.
+    :type timeout: float
     :param port: The port where the server will listen for requests. Default is 9000
+    :type port: int
+    :param host: The IP address where the server will listen for requests. 
+                 Default is 'localhost', which might mean that the server will only accept requests from the local machine.
+                 Use '0.0.0.0' to accept requests from any IP address (if your firewall allows it).
+    :type host: str
     """
 
     def __init__(self, simulator, parallel_sims=4, output_folder='./temp', timeout: float = 300, port=9000,
@@ -54,10 +64,9 @@ class SimServer(object):
         self.output_folder = output_folder
         self.simulation_manager = ServerSimRunner(parallel_sims=parallel_sims, timeout=timeout, verbose=False,
                                                   output_folder=output_folder, simulator=simulator)
-        self.server = SimpleXMLRPCServer(
-                (host, port),
-                # requestHandler=RequestHandler
-        )
+        self.server = SimpleXMLRPCServer((host, port), 
+                                         # requestHandler=RequestHandler
+                                         )
         self.server.register_introspection_functions()
         self.server.register_instance(self)
         self.sessions = {}  # this will contain the session_id ids hashing their respective list of sim_tasks
@@ -162,4 +171,3 @@ class SimServer(object):
 
     def running(self):
         return self.simulation_manager.running()
-


### PR DESCRIPTION
Enhancements on `run_server`:
* no longer needs root
* listens to Ctrl-C and SIGTERM (kill)
* allows setting of IP address to bind to (`-H` parameter)
* update of readme

This covers both #233 and #234

tested on macOS, Linux and Windows, in cross-environment and cross-machine calls. Works!