### PR TITLE
237 documentation creation is broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ spicelib.egg-info
 .DS_Store
 README.bak
 doc_build/
+doc_build_markdown/
 unittests/output/
 examples/testfiles/Batch_Test.exe.log
 examples/testfiles/ngsteps.log

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ POETRY        = poetry
 
 SHELL := /bin/bash
 
-shPRJ2WHEEL = function prj2wheel () { PROJECT=$1; PVER=$$(${POETRY} version -s);echo "dist/$${PROJECT@L}-$${PVER}-py3-none-any.whl"; }
+shPRJ2WHEEL = function prj2wheel () { PROJECT=$1; PVER=$$(${POETRY} version -s);echo "dist/$${PROJECT}-$${PVER}-py3-none-any.whl"; }
 fnPRJ2WHEEL = $(shell ${shPRJ2WHEEL}; prj2wheel "$1")
 
 .PHONY: sphinx-help all help Makefile pyproject.toml doc dist clean doc-clean
@@ -19,9 +19,11 @@ fnPRJ2WHEEL = $(shell ${shPRJ2WHEEL}; prj2wheel "$1")
 help:
 	@echo "Make targets:"
 	@echo "  help        - This help (the default target)"
-	@echo "  sphinx-help - Help with document bulder"
+	@echo "  sphinx-help - Help with document builder"
 	@echo "  all         - Make documentation and distribution targets"
-	@echo "  dist        - Python package wheel and source dist using Poetry"
+	@echo "  doc         - Make HTML documentation"
+	@echo "  html        - Make HTML documentation"
+	@echo "  markdown    - Make Markdown documentation (alternative)"
 	@echo "  dist        - Distribution Python wheel"
 	@echo "  doc-clean   - Destroy built documentation"
 	@echo "  clean       - Destroy all built output"
@@ -30,6 +32,8 @@ help:
 
 all: doc dist
 
+html: doc
+
 sphinx-help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
@@ -37,10 +41,14 @@ sphinx-help:
 doc: Makefile
 	$(SPHINXBUILD) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+markdown:
+	@$(SPHINXBUILD) -b markdown "$(SOURCEDIR)" "$(BUILDDIR)_markdown" $(SPHINXOPTS) $(O)
+
 dist: $(call fnPRJ2WHEEL,${PROJECT})
 
 doc-clean:
 	rm -rf doc_build
+	rm -rf doc_build_markdown
 
 clean: doc-clean
 	rm -rf dist

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,10 @@ SOURCEDIR     = doc
 BUILDDIR      = doc_build
 POETRY        = poetry
 
+# on macOS this should be /usr/local/bin/bash, otherwise you'll get an error "bad substitution". Only needed for dist generation though.
 SHELL := /bin/bash
 
-shPRJ2WHEEL = function prj2wheel () { PROJECT=$1; PVER=$$(${POETRY} version -s);echo "dist/$${PROJECT}-$${PVER}-py3-none-any.whl"; }
+shPRJ2WHEEL = function prj2wheel () { PROJECT=$1; PVER=$$(${POETRY} version -s);echo "dist/$${PROJECT@L}-$${PVER}-py3-none-any.whl"; }
 fnPRJ2WHEEL = $(shell ${shPRJ2WHEEL}; prj2wheel "$1")
 
 .PHONY: sphinx-help all help Makefile pyproject.toml doc dist clean doc-clean

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,3 +5,4 @@ matplotlib
 insipid-sphinx-theme
 autodocsumm
 myst-parser
+poetry


### PR DESCRIPTION
That was more of a macOS and a backwards compatibility thing. Up to you to see if this is worth a merge.

* added poetry, because that is required now.
* prepared a place for markdown docs. TBD where to put that or to keep it. I like it because you would be able to read them from within github and vscode. It is far from complete though.
* all standard targets were gone, therefore it crashed. Added some back. (and removed the duplicate mention of dist)
* The bad substitution messages from the issue are not relevant. They only appear with old bash versions. On macOS you just have to set SHELL := /usr/local/bin/bash because /bin/bash points to an old bash version on macOS.

