### PR TITLE
SimClient and SimServer now handle simulation problems and return a .fail file in case of error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,8 +942,6 @@ import os
 import zipfile
 import logging
 import sys
-
-
 from spicelib.client_server.sim_client import SimClient
 
 # In order for this, to work, you need to have a server running. To start a server, run the following command:
@@ -952,7 +950,6 @@ from spicelib.client_server.sim_client import SimClient
 _logger = logging.getLogger("spicelib.SimClient")
 _logger.setLevel(logging.DEBUG)
 _logger.addHandler(logging.StreamHandler(sys.stdout))
-
 
 server = SimClient('http://localhost', 9000)
 print(server.session_id)
@@ -965,7 +962,7 @@ for runid in server:  # May not arrive in the same order as runids were launched
         print(f"Run id {runid} has no data")
         continue
     # the zip file normally contains a `.raw` and a `.log` file, 
-    # but it can also hold a `.fail` file in case of a simulation error.    
+    # but it can instead only hold a `.fail` file in case of a simulation error.    
     with zipfile.ZipFile(zip_filename, 'r') as zipf:  # Extract the contents of the zip file
         for name in zipf.namelist():
             print(f"Extracting {name} from {zip_filename}")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README <!-- omit in toc -->
 
-_current version: 1.4.5_
+_current version: 1.4.6, preliminary_
 
 *spicelib* is a toolchain of python utilities design to interact with spice simulators, as for example:
 
@@ -941,24 +941,32 @@ SimClient class. An example of its usage is shown below:
 import os
 import zipfile
 import logging
+import sys
+
+
+from spicelib.client_server.sim_client import SimClient
 
 # In order for this, to work, you need to have a server running. To start a server, run the following command:
 # python -m spicelib.scripts.run_server --port 9000 --parallel 4 --output ./temp LTSpice 300
 
 _logger = logging.getLogger("spicelib.SimClient")
 _logger.setLevel(logging.DEBUG)
+_logger.addHandler(logging.StreamHandler(sys.stdout))
 
-from spicelib.client_server.sim_client import SimClient
 
 server = SimClient('http://localhost', 9000)
 print(server.session_id)
 runid = server.run("./testfiles/testfile.net")
 print("Got Job id", runid)
-for runid in server:  # Ma
+for runid in server:  # May not arrive in the same order as runids were launched
     zip_filename = server.get_runno_data(runid)
     print(f"Received {zip_filename} from runid {runid}")
+    if zip_filename is None:
+        print(f"Run id {runid} has no data")
+        continue
+    # the zip file normally contains a `.raw` and a `.log` file, 
+    # but it can also hold a `.fail` file in case of a simulation error.    
     with zipfile.ZipFile(zip_filename, 'r') as zipf:  # Extract the contents of the zip file
-        # print(zipf.namelist())  # Debug printing the contents of the zip file
         for name in zipf.namelist():
             print(f"Extracting {name} from {zip_filename}")
             zipf.extract(name)
@@ -1046,6 +1054,8 @@ in [GitHub spicelib issues](https://github.com/nunobrum/spicelib/issues)
 
 ## History
 
+* Version 1.4.6
+    * Fixing Issue #242 and #243 - Improve error handling in SimServer, and return log information in case of errors.
 * Version 1.4.5
     * Fixing Issue #235 and #236 - Inconsistent formulas in montecarlo.py and in tolerance_deviations.py
     * Fixing Issue #233 and #234 - `run_server` enhancements and platform compatibility

--- a/examples/sim_client_example.py
+++ b/examples/sim_client_example.py
@@ -23,8 +23,6 @@ import os
 import zipfile
 import logging
 import sys
-
-
 from spicelib.client_server.sim_client import SimClient
 
 # In order for this, to work, you need to have a server running. To start a server, run the following command:
@@ -33,7 +31,6 @@ from spicelib.client_server.sim_client import SimClient
 _logger = logging.getLogger("spicelib.SimClient")
 _logger.setLevel(logging.DEBUG)
 _logger.addHandler(logging.StreamHandler(sys.stdout))
-
 
 server = SimClient('http://localhost', 9000)
 print(server.session_id)
@@ -46,7 +43,7 @@ for runid in server:  # May not arrive in the same order as runids were launched
         print(f"Run id {runid} has no data")
         continue
     # the zip file normally contains a `.raw` and a `.log` file, 
-    # but it can also hold a `.fail` file in case of a simulation error.    
+    # but it can instead only hold a `.fail` file in case of a simulation error.    
     with zipfile.ZipFile(zip_filename, 'r') as zipf:  # Extract the contents of the zip file
         for name in zipf.namelist():
             print(f"Extracting {name} from {zip_filename}")

--- a/examples/sim_client_example.py
+++ b/examples/sim_client_example.py
@@ -35,9 +35,12 @@ server = SimClient('http://localhost', 9000)
 print(server.session_id)
 runid = server.run("./testfiles/testfile.net")
 print("Got Job id", runid)
-for runid in server:  # Ma
+for runid in server:  # May not arrive in the same order as runids were launched
     zip_filename = server.get_runno_data(runid)
     print(f"Received {zip_filename} from runid {runid}")
+    if zip_filename is None:
+        print(f"Run id {runid} has no data")
+        continue
     with zipfile.ZipFile(zip_filename, 'r') as zipf:  # Extract the contents of the zip file
         # print(zipf.namelist())  # Debug printing the contents of the zip file
         for name in zipf.namelist():

--- a/examples/sim_client_example.py
+++ b/examples/sim_client_example.py
@@ -22,14 +22,17 @@
 import os
 import zipfile
 import logging
+import sys
+
+from spicelib.client_server.sim_client import SimClient
 
 # In order for this, to work, you need to have a server running. To start a server, run the following command:
 # python -m spicelib.scripts.run_server --port 9000 --parallel 4 --output ./temp LTSpice 300
 
 _logger = logging.getLogger("spicelib.SimClient")
 _logger.setLevel(logging.DEBUG)
+_logger.addHandler(logging.StreamHandler(sys.stdout))
 
-from spicelib.client_server.sim_client import SimClient
 
 server = SimClient('http://localhost', 9000)
 print(server.session_id)

--- a/examples/sim_client_example.py
+++ b/examples/sim_client_example.py
@@ -24,6 +24,7 @@ import zipfile
 import logging
 import sys
 
+
 from spicelib.client_server.sim_client import SimClient
 
 # In order for this, to work, you need to have a server running. To start a server, run the following command:
@@ -44,8 +45,9 @@ for runid in server:  # May not arrive in the same order as runids were launched
     if zip_filename is None:
         print(f"Run id {runid} has no data")
         continue
+    # the zip file normally contains a `.raw` and a `.log` file, 
+    # but it can also hold a `.fail` file in case of a simulation error.    
     with zipfile.ZipFile(zip_filename, 'r') as zipf:  # Extract the contents of the zip file
-        # print(zipf.namelist())  # Debug printing the contents of the zip file
         for name in zipf.namelist():
             print(f"Extracting {name} from {zip_filename}")
             zipf.extract(name)

--- a/examples/sim_server_example.py
+++ b/examples/sim_server_example.py
@@ -32,6 +32,9 @@ simulator = LTspice
 _logger = logging.getLogger("spicelib.SimServer")
 _logger.setLevel(logging.DEBUG)
 _logger.addHandler(logging.StreamHandler(sys.stdout))
+_logger = logging.getLogger("spicelib.ServerSimRunner")
+_logger.setLevel(logging.DEBUG)
+_logger.addHandler(logging.StreamHandler(sys.stdout))
 
 kill_server_requested: bool = False
 

--- a/spicelib/client_server/sim_client.py
+++ b/spicelib/client_server/sim_client.py
@@ -198,7 +198,7 @@ class SimClient(object):
         :return: The name of the zip file containing the simulation output data, or None if not found.
                  The zip file is not guaranteed to hold both a `.raw` file and a `.log` file.
                  It can hold a `.fail` file in case of a simulation error.
-        :rtype: Path
+        :rtype: pathlib.Path
         """
         if runno not in self.stored_jobs:
             raise SimClientInvalidRunId(f"Invalid Job id {runno}")

--- a/spicelib/client_server/sim_client.py
+++ b/spicelib/client_server/sim_client.py
@@ -144,7 +144,7 @@ class SimClient(object):
 
         # Read the zip file from the buffer and send it to the server
         zip_data = zip_buffer.read()
-        # def add_sources(self, session_id: str, zip_data: Binary) -> bool
+        # server side method signature: def add_sources(self, session_id: str, zip_data: Binary) -> bool
         return bool(self.server.add_sources(self.session_id, zip_data))
 
     def run(self, circuit: Union[str, Path], dependencies: Optional[list[Union[str, Path]]] = None) -> int:
@@ -154,10 +154,10 @@ class SimClient(object):
         sequential.
 
         :param circuit: path to the netlist file containing the simulation directives.
-        :type circuit: Path or str
+        :type circuit: pathlib.Path or str
         :param dependencies: list of files that the netlist depends on. This is used to ensure that the netlist is
          transferred to the server with all the necessary files.
-        :type dependencies: list of Path or str
+        :type dependencies: list of pathlib.Path or str
         :returns: identifier on the server of the simulation.
         :rtype: int
         """
@@ -182,7 +182,7 @@ class SimClient(object):
             # Read the zip file from the buffer and send it to the server
             zip_data = zip_buffer.read()
 
-            # def run(self, session_id: str, circuit_name: str, zip_data: Binary) -> int
+            # server side method signature: def run(self, session_id: str, circuit_name: str, zip_data: Binary) -> int
             run_id = int(self.server.run(self.session_id, circuit_name, zip_data))  # type: ignore
             job_info = JobInformation(run_number=run_id, file_dir=circuit_path.parent)
             self.started_jobs[run_id] = job_info
@@ -203,7 +203,7 @@ class SimClient(object):
         if runno not in self.stored_jobs:
             raise SimClientInvalidRunId(f"Invalid Job id {runno}")
 
-        # def get_files(self, session_id, runno) -> tuple[str, Binary]
+        # server side method signature: def get_files(self, session_id, runno) -> tuple[str, Binary]
         zip_filename, zipdata = self.server.get_files(self.session_id, runno)  # type: ignore
         job = self.stored_jobs.pop(runno)  # Removes it from stored jobs
         self.completed_jobs += 1
@@ -220,7 +220,7 @@ class SimClient(object):
 
     def __next__(self):
         while len(self.started_jobs) > 0:
-            # def status(self, session_id: str) -> list[int]
+            # server side method signature: def status(self, session_id: str) -> list[int]
             status: list[int] = self.server.status(self.session_id)  # type: ignore
             if len(status) > 0:
                 runno = status.pop(0)

--- a/spicelib/client_server/sim_server.py
+++ b/spicelib/client_server/sim_server.py
@@ -74,9 +74,13 @@ class SimServer(object):
         self.server_thread = threading.Thread(target=self.server.serve_forever, name="ServerThread")
         self.server_thread.start()
 
-    def add_sources(self, session_id, zip_data) -> bool:
+    def add_sources(self, session_id: str, zip_data: Binary) -> bool:
         """Add sources to the simulation. The sources are contained in a zip file will be added to the simulation
-        folder. Returns True if the sources were added and False if the session_id is not valid. """
+        folder.
+        
+        :return: True if the sources were added, False otherwise
+        :rtype: bool
+        """
         _logger.info(f"Server: Add sources {session_id}")
         if session_id not in self.sessions:
             return False  # This indicates that no job is started
@@ -93,37 +97,49 @@ class SimServer(object):
                 answer = True
         return answer
 
-    def run(self, session_id, circuit_name, zip_data):
+    def run(self, session_id: str, circuit_name: str, zip_data: Binary) -> int:
+        """Runs a simulation for the given circuit.
+
+        :param session_id: The ID of the session to run the simulation in
+        :type session_id: str
+        :param circuit_name: The name of the circuit to simulate
+        :type circuit_name: str
+        :param zip_data: The zip file containing the circuit files
+        :type zip_data: bytes
+        :return: The run number of the simulation
+        :rtype: int
+        """
         _logger.info(f"Server: Run {session_id} : {circuit_name}")
         if not self.add_sources(session_id, zip_data):
             return -1
 
-        circuit_name = Path(self.output_folder) / circuit_name
-        _logger.info(f"Server: Running simulation of {circuit_name}")
-        runno = self.simulation_manager.add_simulation(circuit_name)
+        my_circuit_name = Path(self.output_folder) / circuit_name
+        _logger.info(f"Server: Running simulation of {my_circuit_name}")
+        runno = self.simulation_manager.add_simulation(my_circuit_name)
         if runno != -1:
             self.sessions[session_id].append(runno)
         return runno
 
-    def start_session(self):
+    def start_session(self) -> str:
         """Returns an unique key that represents the session. It will be later used to sort the sim_tasks belonging
-        to the session."""
+        to the session.
+
+        :return: A unique key that represents the session
+        :rtype: str
+        """
         session_id = str(uuid.uuid4())  # Needs to be a string, otherwise the rpc client can't handle it
         _logger.info(f"Server: Starting session {session_id}")
         self.sessions[session_id] = []
         return session_id
 
-    def status(self, session_id):
+    def status(self, session_id: str) -> list[int]:
         """
-        Returns a dictionary with task information. The key for the dictionary is the simulation identifier returned
-        by the simulation start command. The value associated with each simulation identifier is another dictionary
-        containing the following keys:
+        Returns a list with the task numbers that are completed for that session
 
-            * 'completed' - whether the simulation is already finished
-
-            * 'start' - time when the simulation was started
-
-            * 'stop' - server time
+        :param session_id: The ID of the session to check
+        :type session_id: str
+        :return: A list of completed task numbers for the session
+        :rtype: list[int]
         """
         _logger.debug(f"Server: collecting status for {session_id}")
         ret = []
@@ -136,7 +152,16 @@ class SimServer(object):
         _logger.debug(f"Server: Returning status {ret}")
         return ret
 
-    def get_files(self, session_id, runno) -> tuple[str, Binary]:
+    def get_files(self, session_id: str, runno: int) -> tuple[str, Binary]:
+        """Returns the files associated with a specific run number of a completed task in a session.
+
+        :param session_id: The ID of the session to check
+        :type session_id: str
+        :param runno: The run number to check
+        :type runno: int
+        :return: file name and content of the file
+        :rtype: tuple[str, Binary]
+        """
         if runno in self.sessions[session_id]:
 
             for task_info in self.simulation_manager.completed_tasks:
@@ -152,8 +177,12 @@ class SimServer(object):
 
         return "", Binary(b'')  # Returns and empty data
 
-    def close_session(self, session_id):
-        """Cleans all the pending sim_tasks with """
+    def close_session(self, session_id: str):
+        """Cleans all the pending sim_tasks with the session_id.
+
+        :return: True if the session was closed successfully, False otherwise
+        :rtype: bool
+        """
         if session_id not in self.sessions:
             return False
         _logger.info(f"Closing session {session_id}")
@@ -162,12 +191,22 @@ class SimServer(object):
         del self.sessions[session_id]
         return True  # Needs to return always something. None is not supported
 
-    def stop_server(self):
+    def stop_server(self) -> bool:
+        """Stops the server and cleans up resources.
+
+        :return: True if the server was stopped successfully, False otherwise
+        :rtype: bool
+        """
         _logger.debug("Server: stopping...ServerInterface")
         self.simulation_manager.stop()
         self.server.shutdown()
         _logger.info("Server: stopped...ServerInterface")
         return True  # Needs to return always something. None is not supported
 
-    def running(self):
+    def running(self) -> bool:
+        """Checks if the server is currently running.
+
+        :return: True if the server is running, False otherwise
+        :rtype: bool
+        """
         return self.simulation_manager.running()

--- a/spicelib/client_server/srv_sim_runner.py
+++ b/spicelib/client_server/srv_sim_runner.py
@@ -20,21 +20,43 @@
 # -------------------------------------------------------------------------------
 import threading
 import time
-from typing import Union, Any
+from typing import Union, Any, Optional
 from pathlib import Path
 import zipfile
 import logging
-_logger = logging.getLogger("spicelib.ServerSimRunner")
 
 from ..sim.sim_runner import SimRunner
 from ..editor.base_editor import BaseEditor
 
+_logger = logging.getLogger("spicelib.ServerSimRunner")
 
-def zip_files(raw_filename: Path, log_filename: Path):
-    zip_filename = raw_filename.with_suffix('.zip')
+
+def zip_files(raw_filename: Optional[Path], log_filename: Optional[Path]) -> Optional[Path]:
+    """Zips the raw and log files into a single zip file.
+
+    :param raw_filename: The path to the raw file.
+    :type raw_filename: Optional[Path]
+    :param log_filename: The path to the log file.
+    :type log_filename: Optional[Path]
+    :return: The path to the zip file or None if no files were provided.
+    :rtype: Optional[Path]
+    """
+    zip_filename = None
+    if isinstance(raw_filename, Path) and raw_filename.exists():
+        zip_filename = raw_filename.with_suffix('.zip')
+    else:
+        if isinstance(log_filename, Path) and log_filename.exists():
+            zip_filename = log_filename.with_suffix('.zip')
+            
+    if zip_filename is None:
+        _logger.warning("No files are available for zipping. Returning None.")
+        return None
+
     with zipfile.ZipFile(zip_filename, 'w', zipfile.ZIP_DEFLATED) as zip_file:
-        zip_file.write(raw_filename)
-        zip_file.write(log_filename)
+        if isinstance(raw_filename, Path) and raw_filename.exists():
+            zip_file.write(raw_filename)
+        if isinstance(log_filename, Path) and log_filename.exists():
+            zip_file.write(log_filename)
     return zip_filename
 
 
@@ -49,8 +71,8 @@ class ServerSimRunner(threading.Thread):
     by this class.
     """
 
-    def __init__(self, parallel_sims: int = 4, timeout: float = None, verbose=False,
-                 output_folder: str = None, simulator=None):
+    def __init__(self, parallel_sims: int = 4, timeout: float = 600.0, verbose=False,
+                 output_folder: Optional[str] = None, simulator=None):
         super().__init__(name="SimManager")
         self.runner = SimRunner(simulator=simulator, parallel_sims=parallel_sims, timeout=timeout,
                                 verbose=verbose, output_folder=output_folder)
@@ -92,7 +114,7 @@ class ServerSimRunner(threading.Thread):
         self.runner.wait_completion()
         self.runner.cleanup_files()  # Delete things that have been left behind
 
-    def add_simulation(self, netlist: Union[str, Path, BaseEditor], *, timeout: float = None) -> int:
+    def add_simulation(self, netlist: Union[str, Path, BaseEditor], *, timeout: Optional[float] = None) -> int:
         """
         Adding a simulation to the list of simulations to be run. The function will return the runno of the simulation
         or -1 if the simulation could not be started.
@@ -102,7 +124,7 @@ class ServerSimRunner(threading.Thread):
         :return: The runno of the simulation or -1 if the simulation could not be started
         """
         _logger.debug(f"starting Simulation of {netlist}")
-        task = self.runner.run(netlist, wait_resource=True, timeout=timeout, callback=zip_files)
+        task = self.runner.run(netlist, wait_resource=True, timeout=timeout, callback=zip_files, callback_on_error=True)
         if task is None:
             _logger.error(f"Failed to start task {netlist}")
             return -1

--- a/spicelib/client_server/srv_sim_runner.py
+++ b/spicelib/client_server/srv_sim_runner.py
@@ -111,23 +111,32 @@ class ServerSimRunner(threading.Thread):
             return task.runno
 
     def _erase_files_and_info(self, pos):
+        # _logger.debug(f"deleting files for task at position {pos}")
         task = self.completed_tasks[pos]
         for filename in ('circuit', 'log', 'raw', 'zipfile'):
-            f = task[filename]
-            if f.exists():
-                _logger.info(f"deleting {f}")
-                f.unlink()
+            if filename in task:
+                f = task[filename]
+                if f is not None and f.exists():
+                    _logger.debug(f"deleting file {f}")
+                    try:
+                        f.unlink()
+                        _logger.debug(f"deleted file {f}")
+                    except Exception as e:
+                        _logger.error(f"Error deleting file {f}: {e}")
         del self.completed_tasks[pos]
 
     def erase_files_of_runno(self, runno):
         """Will delete all files related with a completed task. Will also delete information on the completed_tasks
         attribute."""
+        _logger.debug(f"deleting files of run {runno}")
         for i, task_info in enumerate(self.completed_tasks):
             if task_info['runno'] == runno:
                 self._erase_files_and_info(i)
+                # _logger.debug(f"deleting files of run {runno} - done")
                 break
 
     def cleanup_completed(self):
+        _logger.debug("deleting all files of all completed tasks")
         while len(self.completed_tasks):
             self._erase_files_and_info(0)
 

--- a/spicelib/client_server/srv_sim_runner.py
+++ b/spicelib/client_server/srv_sim_runner.py
@@ -35,9 +35,9 @@ def zip_files(raw_filename: Optional[Path], log_filename: Optional[Path]) -> Opt
     """Zips the raw and log files into a single zip file.
 
     :param raw_filename: The path to the raw file.
-    :type raw_filename: Optional[Path]
+    :type raw_filename: Optional[pathlib.Path]
     :param log_filename: The path to the log file.
-    :type log_filename: Optional[Path]
+    :type log_filename: Optional[pathlib.Path]
     :return: The path to the zip file or None if no files were provided.
     :rtype: Optional[Path]
     """

--- a/spicelib/client_server/srv_sim_runner.py
+++ b/spicelib/client_server/srv_sim_runner.py
@@ -133,7 +133,6 @@ class ServerSimRunner(threading.Thread):
             return task.runno
 
     def _erase_files_and_info(self, pos):
-        # _logger.debug(f"deleting files for task at position {pos}")
         task = self.completed_tasks[pos]
         for filename in ('circuit', 'log', 'raw', 'zipfile'):
             if filename in task:
@@ -154,7 +153,6 @@ class ServerSimRunner(threading.Thread):
         for i, task_info in enumerate(self.completed_tasks):
             if task_info['runno'] == runno:
                 self._erase_files_and_info(i)
-                # _logger.debug(f"deleting files of run {runno} - done")
                 break
 
     def cleanup_completed(self):

--- a/spicelib/editor/asc_editor.py
+++ b/spicelib/editor/asc_editor.py
@@ -85,7 +85,7 @@ class AscEditor(BaseSchematic):
         For writing to a .net or .cir file, use the `LTspice.create_netlist()` method instead.
 
         :param run_netlist_file: File name of the netlist file.
-        :type run_netlist_file: Path or str
+        :type run_netlist_file: pathlib.Path or str
         :returns: Nothing
         """        
         if isinstance(run_netlist_file, str):

--- a/spicelib/editor/base_editor.py
+++ b/spicelib/editor/base_editor.py
@@ -414,7 +414,7 @@ class BaseEditor(ABC):
         Saves the current state of the netlist to a file.
 
         :param run_netlist_file: File name of the netlist file.
-        :type run_netlist_file: Path or str
+        :type run_netlist_file: pathlib.Path or str
         :returns: Nothing
         """
         ...

--- a/spicelib/editor/base_editor.py
+++ b/spicelib/editor/base_editor.py
@@ -28,7 +28,7 @@ from typing import Union
 import logging
 import os
 
-from .updates import UpdateType, Update, Updates
+from .updates import UpdateType, Updates
 from ..sim.simulator import Simulator
 
 
@@ -522,7 +522,7 @@ class BaseEditor(ABC):
 
         :return: Nothing
         """
-        update = self.add_update(param, value, UpdateType.UpdateParameter)
+        self.add_update(param, value, UpdateType.UpdateParameter)
 
     def set_parameters(self, **kwargs):
         """Adds one or more parameters to the netlist.

--- a/spicelib/editor/qsch_editor.py
+++ b/spicelib/editor/qsch_editor.py
@@ -537,7 +537,7 @@ class QschEditor(BaseSchematic):
         Saves the current state of the netlist to a .qsh or to a .net or .cir file.
 
         :param run_netlist_file: File name of the netlist file. Can be .qsch, .net or .cir
-        :type run_netlist_file: Path or str
+        :type run_netlist_file: pathlib.Path or str
         :returns: Nothing
         """
         if isinstance(run_netlist_file, str):

--- a/spicelib/editor/spice_editor.py
+++ b/spicelib/editor/spice_editor.py
@@ -1401,7 +1401,7 @@ class SpiceEditor(SpiceCircuit):
     netlist file.
 
     :param netlist_file: Name of the .NET file to parse
-    :type netlist_file: str or Path
+    :type netlist_file: str or pathlib.Path
     :param encoding: Forcing the encoding to be used on the circuit netlile read. Defaults to 'autodetect' which will
         call a function that tries to detect the encoding automatically. This however is not 100% foolproof.
     :type encoding: str, optional

--- a/spicelib/editor/updates.py
+++ b/spicelib/editor/updates.py
@@ -1,9 +1,9 @@
 import dataclasses
 import enum
 from copy import deepcopy
-from typing import Union, Optional
+from typing import Union
 
-UpdateValueType = Union[str, int, float]
+UpdateValueType = Union[str, int, float, None]
 
 
 class UpdateType(enum.Enum):
@@ -72,9 +72,9 @@ class Updates:
     def __len__(self):
         return len(self.netlist_updates)
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: Union[int, slice, str]) -> Union[Update, list[Update]]:
         if isinstance(item, (int, slice)):
-            return self.netlist_updates[item]
+            return self.netlist_updates[item]  # with item = slice, we could get a list here. Otherwise, it is a single Update
         elif isinstance(item, str):
             # Try to get it by name
             for update in self.netlist_updates:
@@ -88,7 +88,7 @@ class Updates:
         """Clear the list of updates."""
         self.netlist_updates.clear()
 
-    def add_update(self, name: str, value: Optional[UpdateValueType], updates: UpdateType):
+    def add_update(self, name: str, value: UpdateValueType, updates: UpdateType):
         """Add an update to the list"""
         for update in self.netlist_updates:
             if (update.name == name and
@@ -103,7 +103,7 @@ class Updates:
         update.value = value
         return update
 
-    def value(self, reference) -> Optional[UpdateValueType]:
+    def value(self, reference) -> UpdateValueType:
         "Get the value update done to a component. Returns None if there wasn't any update."
         for update in self.netlist_updates:
             if update.updates == UpdateType.UpdateComponentValue and update.name == reference:

--- a/spicelib/log/qspice_log_reader.py
+++ b/spicelib/log/qspice_log_reader.py
@@ -109,7 +109,7 @@ class QspiceLogReader(LogfileData):
 
         :param meas_filename: This optional parameter specifies the measurement file name. If not given, it will
             assume the name of the log file but with the extension '.meas'.
-        :type meas_filename: Optional str or Path
+        :type meas_filename: Optional str or pathlib.Path
         :returns: The .meas file path
         :rtype: Path
         """
@@ -145,7 +145,7 @@ class QspiceLogReader(LogfileData):
         using this class interface.
 
         :param meas_filename: path to the measurement file to parse.
-        :type meas_filename: str or Path
+        :type meas_filename: str or pathlib.Path
         :returns: Nothing
         """
         meas_regex = re.compile(r"^\.meas (\w+) (\w+) (.*)$")

--- a/spicelib/log/qspice_log_reader.py
+++ b/spicelib/log/qspice_log_reader.py
@@ -111,7 +111,7 @@ class QspiceLogReader(LogfileData):
             assume the name of the log file but with the extension '.meas'.
         :type meas_filename: Optional str or pathlib.Path
         :returns: The .meas file path
-        :rtype: Path
+        :rtype: pathlib.Path
         """
         if meas_filename is None:
             meas_filename = self.logname.with_suffix(".meas")

--- a/spicelib/raw/raw_read.py
+++ b/spicelib/raw/raw_read.py
@@ -591,7 +591,7 @@ class PlotInterface(Protocol):
         Saves the data to an Excel file.
         
         :param filename: Name of the file to save the data to
-        :type filename: Union[str, Path]
+        :type filename: Union[str, pathlib.Path]
         :param columns: List of traces to use as columns. Default is None, meaning all traces
         :type columns: list, optional
         :param step: Step number to retrieve, defaults to -1
@@ -1488,7 +1488,7 @@ class PlotData(PlotInterface):
         Saves the data to an Excel file.
         
         :param filename: Name of the file to save the data to
-        :type filename: Union[str, Path]
+        :type filename: Union[str, pathlib.Path]
         :param columns: List of traces to use as columns. Default is None, meaning all traces
         :type columns: list, optional
         :param step: Step number to retrieve, defaults to -1
@@ -1631,7 +1631,7 @@ class RawRead(PlotInterface):
         """Detects the encoding of the RAW file.
         
         :param raw_file: The file object to read from
-        :type raw_file: Path
+        :type raw_file: pathlib.Path
         :return: The encoding of the RAW file
         :rtype: str
         :raises EncodingDetectError: if the encoding cannot be detected
@@ -1990,7 +1990,7 @@ class RawRead(PlotInterface):
         Saves the data to an Excel file.
         
         :param filename: Name of the file to save the data to
-        :type filename: Union[str, Path]
+        :type filename: Union[str, pathlib.Path]
         :param columns: List of traces to use as columns. Default is None, meaning all traces
         :type columns: list, optional
         :param step: Step number to retrieve, defaults to -1

--- a/spicelib/raw/raw_read.py
+++ b/spicelib/raw/raw_read.py
@@ -1511,7 +1511,7 @@ class RawRead(PlotInterface):
     If stepped data is detected, it will also try to read the corresponding LOG file so to retrieve the stepped data.
 
     :param raw_filename: The file containing the RAW data to be read
-    :type raw_filename: str | pahtlib.Path
+    :type raw_filename: str or pathlib.Path
     :param traces_to_read:
         A string or a list containing the list of traces to be read. If None is provided, only the header is read and
         all trace data is discarded. If a '*' wildcard is given or no parameter at all then all traces are read.

--- a/spicelib/raw/raw_write.py
+++ b/spicelib/raw/raw_write.py
@@ -149,7 +149,7 @@ class RawWrite(object):
         in this version.
         
         :param filename: filename to where the RAW file is going to be written. Make sure that the extension of the file is .RAW.
-        :type filename: str or pathlib.Path
+        :type filename: str or Path
         :return: Nothing
         """
         if len(self._imported_data):

--- a/spicelib/raw/raw_write.py
+++ b/spicelib/raw/raw_write.py
@@ -149,7 +149,7 @@ class RawWrite(object):
         in this version.
         
         :param filename: filename to where the RAW file is going to be written. Make sure that the extension of the file is .RAW.
-        :type filename: str or Path
+        :type filename: str or pathlib.Path
         :return: Nothing
         """
         if len(self._imported_data):

--- a/spicelib/sim/run_task.py
+++ b/spicelib/sim/run_task.py
@@ -192,8 +192,8 @@ class RunTask(threading.Thread):
         Returns the simulation outputs if the simulation and callback function has already finished.
         If the simulation is not finished, it simply returns None. If no callback function is defined, then
         it returns a tuple with (raw_file, log_file).
-        If a callback function is defined, it returns whatever the callback function is returning.
-        If a callback function is defined, the simulation failed, and `callback_on_error` is False (default), it returns None.
+        If a callback function is defined, it returns whatever the callback function is returning, unless
+        the simulation failed, and `callback_on_error` is False (default), in which case it returns None.
 
         :returns: Tuple with the path to the raw file and the path to the log file
         :rtype: tuple(str, str) or None

--- a/spicelib/sim/run_task.py
+++ b/spicelib/sim/run_task.py
@@ -63,10 +63,11 @@ class RunTask(threading.Thread):
     """This is an internal Class and should not be used directly by the User."""
 
     def __init__(self, simulator: Type[Simulator], runno, netlist_file: Path,
-                 callback: Optional[Union[Type[ProcessCallback], Callable[[Path, Path], Any]]],
+                 callback: Optional[Union[Type[ProcessCallback], Callable[[Optional[Path], Optional[Path]], Any]]],
                  callback_args: Union[dict, None] = None,
                  switches: Any = None, timeout: Union[float, None] = None, verbose: bool = False,
                  cwd: Union[str, Path, None] = None,
+                 callback_on_error: bool = False,
                  exe_log: bool = False):
 
         super().__init__(name=f"RunTask#{runno}")
@@ -80,6 +81,7 @@ class RunTask(threading.Thread):
         self.netlist_file = netlist_file
         self.callback = callback
         self.callback_args = callback_args
+        self.callback_on_error = callback_on_error
         self.cwd = cwd
         self.retcode = -1  # Signals an error by default
         self.raw_file = None
@@ -111,6 +113,10 @@ class RunTask(threading.Thread):
     def run(self):
         # Running the Simulation
 
+        self.callback_return = None
+        self.raw_file = None
+        self.log_file = None
+        
         self.start_time = time.time()
         self.print_info(_logger.info, ": Starting simulation %d: %s" % (self.runno, self.netlist_file))
         # start execution
@@ -128,6 +134,8 @@ class RunTask(threading.Thread):
         sim_time = format_time_difference(self.stop_time - self.start_time)
         # Format the time difference
         self.log_file = self.netlist_file.with_suffix('.log')
+        
+        some_error = False
 
         # Cleanup everything
         if self.retcode == 0:
@@ -135,69 +143,68 @@ class RunTask(threading.Thread):
             if self.raw_file.exists() and self.log_file.exists():
                 # simulation successful
                 self.print_info(_logger.info, "Simulation Successful. Time elapsed: %s" % sim_time)
-
-                if self.callback:
-                    if self.callback_args is not None:
-                        callback_print = ', '.join([f"{key}={value}" for key, value in self.callback_args.items()])
-                    else:
-                        callback_print = ''
-                    self.print_info(_logger.info, "Simulation Finished. Calling...{}(rawfile, logfile{})".format(
-                        self.callback.__name__, callback_print))
-                    try:
-                        if self.callback_args is not None:
-                            return_or_process = self.callback(self.raw_file, self.log_file, **self.callback_args)
-                        else:
-                            return_or_process = self.callback(self.raw_file, self.log_file)
-                    except Exception:
-                        error = traceback.format_exc()
-                        self.print_info(_logger.error, error)
-                    else:
-                        if isinstance(return_or_process, ProcessCallback):
-                            proc = return_or_process
-                            proc.start()
-                            self.callback_return = proc.queue.get()
-                            proc.join()
-                        else:
-                            self.callback_return = return_or_process
-                    finally:
-                        callback_start_time = self.stop_time
-                        self.stop_time = time.time()
-                        self.print_info(_logger.info, "Callback Finished. Time elapsed: %s" % format_time_difference(
-                            self.stop_time - callback_start_time))
-                else:
-                    self.print_info(_logger.info, "Simulation Finished. No Callback function given")
             else:
                 self.print_info(_logger.error, "Simulation Raw file or Log file were not found")
+                some_error = True
         else:
             # simulation failed
+            some_error = True
             self.print_info(_logger.error, "Simulation Aborted. Time elapsed: %s" % sim_time)
             if self.log_file.exists():
                 self.log_file = self.log_file.replace(self.log_file.with_suffix('.fail'))
+
+        # Do I need to use callback?
+        if self.callback and (self.callback_on_error or not some_error):
+            # If the callback function is defined and callback_on_error is True, call the callback function
+            # even if the simulation failed
+            if self.callback_args is not None:
+                callback_print = ', '.join([f"{key}={value}" for key, value in self.callback_args.items()])
+            else:
+                callback_print = ''
+            self.print_info(_logger.info, f"Simulation Finished. Calling...{self.callback.__name__}(rawfile, logfile{callback_print})")
+            try:
+                if self.callback_args is not None:
+                    return_or_process = self.callback(self.raw_file, self.log_file, **self.callback_args)
+                else:
+                    return_or_process = self.callback(self.raw_file, self.log_file)
+            except Exception:
+                error = traceback.format_exc()
+                self.print_info(_logger.error, error)
+            else:
+                if isinstance(return_or_process, ProcessCallback):
+                    proc = return_or_process
+                    proc.start()
+                    self.callback_return = proc.queue.get()
+                    proc.join()
+                else:
+                    self.callback_return = return_or_process
+            finally:
+                callback_start_time = self.stop_time
+                self.stop_time = time.time()
+                self.print_info(_logger.info, "Simulation Callback Finished. Time elapsed: %s" % format_time_difference(
+                    self.stop_time - callback_start_time))
+        else:
+            self.print_info(_logger.debug, "Simulation Callback not called.")
+            self.callback_return = None
 
     def get_results(self) -> Union[None, Any, tuple[str, str]]:
         """
         Returns the simulation outputs if the simulation and callback function has already finished.
         If the simulation is not finished, it simply returns None. If no callback function is defined, then
-        it returns a tuple with (raw_file, log_file). If a callback function is defined, and the simulation succeeded,
-        it returns whatever the callback function is returning. If the simulation failed and a callback function is defined,
-        it returns None.
-        
+        it returns a tuple with (raw_file, log_file).
+        If a callback function is defined, it returns whatever the callback function is returning.
+        If a callback function is defined, the simulation failed, and `callback_on_error` is False (default), it returns None.
+
         :returns: Tuple with the path to the raw file and the path to the log file
         :rtype: tuple(str, str) or None
         """
         if self.is_alive() or self.start_time is None:  # running or not yet started
             return None
 
-        if self.retcode == 0:  # All finished OK
-            if self.callback:
-                return self.callback_return
-            else:
-                return self.raw_file, self.log_file
+        if self.callback:
+            return self.callback_return  # callback_return is guaranteed to be set correctly by `run()`
         else:
-            if self.callback:
-                return None
-            else:
-                return self.raw_file, self.log_file
+            return self.raw_file, self.log_file
 
     def wait_results(self) -> Union[Any, tuple[str, str]]:
         """

--- a/spicelib/sim/run_task.py
+++ b/spicelib/sim/run_task.py
@@ -185,7 +185,7 @@ class RunTask(threading.Thread):
         :returns: Tuple with the path to the raw file and the path to the log file
         :rtype: tuple(str, str) or None
         """
-        if self.is_alive():
+        if self.is_alive() or self.start_time is None:  # running or not yet started
             return None
 
         if self.retcode == 0:  # All finished OK
@@ -206,6 +206,6 @@ class RunTask(threading.Thread):
         :returns: Tuple with the path to the raw file and the path to the log file. See get_results() for more details.
         :rtype: tuple(str, str)
         """
-        while self.is_alive() or self.retcode == -1:
+        while self.is_alive() or self.start_time is None or self.retcode == -1:
             sleep(0.1)
         return self.get_results()

--- a/spicelib/sim/sim_runner.py
+++ b/spicelib/sim/sim_runner.py
@@ -103,11 +103,10 @@ __copyright__ = "Copyright 2020, Fribourg Switzerland"
 
 __all__ = ['SimRunner', 'SimRunnerTimeoutError', 'AnyRunner', 'ProcessCallback', 'RunTask']
 
-import pathlib
+from pathlib import Path
 import shutil
 import inspect  # Library used to get the arguments of the callback function
 import time
-from pathlib import Path
 from time import sleep, thread_time as clock
 from typing import Callable, Union, Type, Protocol, Iterator, Any, Optional
 import logging
@@ -471,7 +470,7 @@ class SimRunner(AnyRunner):
                 netlist = Path(netlist)
             run_netlist_file = self._to_output_folder(netlist, copy=True, new_name=run_filename)
         else:
-            raise TypeError("'netlist' parameter shall be a SpiceEditor, pathlib.Path or a plain str")
+            raise TypeError("'netlist' parameter shall be a SpiceEditor, Path or a plain str")
 
         return run_netlist_file
 
@@ -824,14 +823,14 @@ class SimRunner(AnyRunner):
         """
         return TaskIterator(self, lambda x: x, True, conditions)
 
-    def create_raw_file_with(self, raw_filename: Union[pathlib.Path, str], save: list[str],
+    def create_raw_file_with(self, raw_filename: Union[Path, str], save: list[str],
                              conditions: IteratorFilterType) -> bool:
         """
         Creates a new raw_file, with traces belonging to different runs. The type of the raw file is the same as
         the first raw file that is matching the conditions. See filter_completed_tasks() method.
 
         :param raw_filename: The new RAW filename
-        :type raw_filename: str or pathlib.Path
+        :type raw_filename: str or Path
         :param save: A list with traces that are going to be saved in the new raw file
         :type save: list[str]
         :param conditions: A filter as specified on the TaskIterator class

--- a/spicelib/sim/sim_runner.py
+++ b/spicelib/sim/sim_runner.py
@@ -666,7 +666,7 @@ class SimRunner(AnyRunner):
         """
         i = 0
         while i < len(self.active_tasks):
-            if self.active_tasks[i].is_alive():
+            if self.active_tasks[i].is_alive() or self.active_tasks[i].start_time is None:  # running or not yet started
                 i += 1
             else:
                 if self.active_tasks[i].retcode == 0:

--- a/spicelib/sim/sim_runner.py
+++ b/spicelib/sim/sim_runner.py
@@ -516,6 +516,7 @@ class SimRunner(AnyRunner):
             switches=None,
             timeout: Union[float, None] = None,
             run_filename: Union[str, None] = None,
+            callback_on_error: bool = False,
             exe_log: bool = False) -> Union[RunTask, None]:
         """
         Executes a simulation run with the conditions set by the user.
@@ -555,7 +556,11 @@ class SimRunner(AnyRunner):
         :type timeout: float, optional
         :param run_filename: Name to be used for the log and raw file.
         :type run_filename: str or Path
-        :param exe_log: If True, the simulator's execution console messages will be written to a log file 
+        :param callback_on_error: If False (default), the callback function is not called if the simulation fails.
+            If True, the callback function is called even if the simulation fails.
+            Know that in that case it is not guaranteed that the raw and log files will be available.
+        :type callback_on_error: bool, optional
+        :param exe_log: If True, the simulator's execution console messages will be written to a log file
             (named ...exe.log) instead of console. This is especially useful when running under wine or when running
             simultaneous tasks.
         :type exe_log: bool, optional        
@@ -580,7 +585,7 @@ class SimRunner(AnyRunner):
                     simulator=self.simulator, runno=self._runno, netlist_file=run_netlist_file,
                     callback=callback, callback_args=callback_kwargs,
                     switches=cmdline_switches, timeout=timeout, verbose=self.verbose,
-                    cwd=self.cwd, exe_log=exe_log
+                    cwd=self.cwd, callback_on_error=callback_on_error, exe_log=exe_log
                 )
                 if isinstance(netlist, BaseEditor) and netlist.netlist_updates is not None:
                     t.edits = netlist.netlist_updates  # Copy is made in this assignment
@@ -635,7 +640,7 @@ class SimRunner(AnyRunner):
             simulator=self.simulator, runno=self._runno, netlist_file=run_netlist_file,
             callback=dummy_callback, callback_args=None,
             switches=cmdline_switches, timeout=timeout, verbose=self.verbose,
-            cwd=self.cwd, exe_log=exe_log
+            cwd=self.cwd, callback_on_error=False, exe_log=exe_log
         )
         if isinstance(netlist, BaseEditor) and netlist.netlist_updates is not None:
             t.edits = netlist.netlist_updates  # Copy is made in this assignment

--- a/spicelib/sim/sim_runner.py
+++ b/spicelib/sim/sim_runner.py
@@ -548,7 +548,7 @@ class SimRunner(AnyRunner):
             function, the first two parameters are the raw and log files. The other parameters are passed as dictionary
             in the callback_args parameter.
 
-        :type: callback: function(raw_file: Path, log_file: Path, ...), optional
+        :type callback: function(raw_file: pathlib.Path, log_file: pathlib.Path, ...), optional
         :param callback_args:
             The callback function arguments. This parameter is passed as keyword arguments to the callback function.
         :type callback_args: dict or tuple, optional

--- a/spicelib/sim/sim_stepping.py
+++ b/spicelib/sim/sim_stepping.py
@@ -184,7 +184,7 @@ class SimStepper(AnyRunner):
         wait_completion parameters.
 
         :param callback: See the SimRunner run method.
-        :type: callback: function(raw_file: Path, log_file: Path, ...), optional
+        :type callback: function(raw_file: pathlib.Path, log_file: pathlib.Path, ...), optional
         :param callback_args: See the SimRunner run method.
         :type callback_args: dict or tuple, optional
         :param switches: Command line switches override

--- a/spicelib/sim/sim_stepping.py
+++ b/spicelib/sim/sim_stepping.py
@@ -253,7 +253,7 @@ class SimStepper(AnyRunner):
         there were set for that simulation.
 
         :param export_filename: export file path
-        :type export_filename: str or Path
+        :type export_filename: str or pathlib.Path
         :param delimiter: delimiter character on the CSV
         :type delimiter: str
         """

--- a/spicelib/sim/sim_stepping.py
+++ b/spicelib/sim/sim_stepping.py
@@ -23,7 +23,7 @@
 __author__ = "Nuno Canto Brum <nuno.brum@gmail.com>"
 __copyright__ = "Copyright 2017, Fribourg Switzerland"
 
-import pathlib
+from pathlib import Path
 from typing import Callable, Union, Type, Iterable
 from functools import wraps
 import logging
@@ -243,7 +243,7 @@ class SimStepper(AnyRunner):
             # Now waits for the simulations to end
             self.runner.wait_completion()
 
-    def export_step_info(self, export_filename: Union[pathlib.Path, str], delimiter: str = ";"):
+    def export_step_info(self, export_filename: Union[Path, str], delimiter: str = ";"):
         """
         Exports the stepping values to a CSV file. It writes a row per each simulation done.
         The columns are all the values that were set during the session. The value on each row is the value
@@ -253,7 +253,7 @@ class SimStepper(AnyRunner):
         there were set for that simulation.
 
         :param export_filename: export file path
-        :type export_filename: str or pathlib.Path
+        :type export_filename: str or Path
         :param delimiter: delimiter character on the CSV
         :type delimiter: str
         """
@@ -279,7 +279,7 @@ class SimStepper(AnyRunner):
                 row_data_with_id.update(self.sim_info[runno])
                 writer.writerow(row_data_with_id)
 
-    # def run(self, netlist: Union[str, pathlib.Path, BaseEditor], *,
+    # def run(self, netlist: Union[str, Path, BaseEditor], *,
     #         wait_resource: bool = True,
     #         callback: Union[Type[ProcessCallback], Callable] = None,
     #         callback_args: Union[tuple, dict] = None,

--- a/spicelib/sim/simulator.py
+++ b/spicelib/sim/simulator.py
@@ -108,8 +108,8 @@ class Simulator(ABC):
         Creates a simulator class from a path to the simulator executable
         
         :param path_to_exe:
-        :type path_to_exe: Path or str. If it is a string, it supports multiple sections, 
-            allowing loaders like wine, but MUST be in posix format in that case, and 
+        :type path_to_exe: pathlib.Path or str. If it is a string, it supports multiple sections,
+            allowing loaders like wine, but MUST be in posix format in that case, and
             the last section MUST be the simulator executable.
         :param process_name: the process_name to be used for killing phantom processes. If not provided, it will be 
         :return: a class instance representing the Spice simulator

--- a/spicelib/sim/simulator.py
+++ b/spicelib/sim/simulator.py
@@ -108,7 +108,7 @@ class Simulator(ABC):
         Creates a simulator class from a path to the simulator executable
         
         :param path_to_exe:
-        :type path_to_exe: pathlib.Path or str. If it is a string, it supports multiple sections, 
+        :type path_to_exe: Path or str. If it is a string, it supports multiple sections, 
             allowing loaders like wine, but MUST be in posix format in that case, and 
             the last section MUST be the simulator executable.
         :param process_name: the process_name to be used for killing phantom processes. If not provided, it will be 

--- a/spicelib/simulators/ltspice_simulator.py
+++ b/spicelib/simulators/ltspice_simulator.py
@@ -331,7 +331,7 @@ class LTspice(Simulator):
         :raises NotImplementedError: when the requested execution is not possible on this platform.
         :raises RuntimeError: when the netlist cannot be created
         :return: path to the netlist produced
-        :rtype: Path
+        :rtype: pathlib.Path
         """
         if not cls.is_available():
             _logger.error("================== ALERT! ====================")

--- a/spicelib/simulators/ltspice_simulator.py
+++ b/spicelib/simulators/ltspice_simulator.py
@@ -244,7 +244,7 @@ class LTspice(Simulator):
         but with `.raw` and `.log` extension.        
 
         :param netlist_file: path to the netlist file
-        :type netlist_file: Union[str, Path]
+        :type netlist_file: Union[str, pathlib.Path]
         :param cmd_line_switches: additional command line options. Best to have been validated by valid_switch(), defaults to None
         :type cmd_line_switches: list, optional
         :param timeout: If timeout is given, and the process takes too long, a TimeoutExpired exception will be raised, defaults to None
@@ -256,7 +256,7 @@ class LTspice(Simulator):
         :param stderr: Like stdout, but affecting the command's error output. Also see `exe_log` for a simpler form of control.
         :type stderr: _FILE, optional
         :param cwd: The current working directory to run the command in. If None, no change will be done of the working directory. This may not work as wanted when using the simulator under wine.
-        :type cwd: Union[str, Path, None], optional
+        :type cwd: Union[str, pathlib.Path, None], optional
         :param exe_log: If True, stdout and stderr will be ignored, and the simulator's execution console messages will be written to a log file 
             (named ...exe.log) instead of console. This is especially useful when running under wine or when running simultaneous tasks.
         :type exe_log: bool, optional            
@@ -312,7 +312,7 @@ class LTspice(Simulator):
         """Create a netlist out of the circuit file
 
         :param circuit_file: path to the circuit file
-        :type circuit_file: Union[str, Path]
+        :type circuit_file: Union[str, pathlib.Path]
         :param cmd_line_switches: additional command line options. Best to have been validated by valid_switch(), defaults to None
         :type cmd_line_switches: list, optional
         :param timeout: If timeout is given, and the process takes too long, a TimeoutExpired exception will be raised, defaults to None
@@ -324,7 +324,7 @@ class LTspice(Simulator):
         :param stderr: Like stdout, but affecting the command's error output. Also see `exe_log` for a simpler form of control.
         :type stderr: _FILE, optional
         :param cwd: The current working directory to run the command in. If None, no change will be done of the working directory. This may not work as wanted when using the simulator under wine.
-        :type cwd: Union[str, Path, None], optional
+        :type cwd: Union[str, pathlib.Path, None], optional
         :param exe_log: If True, stdout and stderr will be ignored, and the simulator's execution console messages will be written to a log file 
             (named ...exe.log) instead of console. This is especially useful when running under wine or when running simultaneous tasks.
         :type exe_log: bool, optional            

--- a/spicelib/simulators/ngspice_simulator.py
+++ b/spicelib/simulators/ngspice_simulator.py
@@ -177,7 +177,7 @@ class NGspiceSimulator(Simulator):
         but with `.raw` and `.log` extension.
 
         :param netlist_file: path to the netlist file
-        :type netlist_file: Union[str, Path]
+        :type netlist_file: Union[str, pathlib.Path]
         :param cmd_line_switches: additional command line options. Best to have been validated by valid_switch(), defaults to None
         :type cmd_line_switches: list, optional
         :param timeout: If timeout is given, and the process takes too long, a TimeoutExpired exception will be raised, defaults to None
@@ -189,8 +189,8 @@ class NGspiceSimulator(Simulator):
         :param stderr: Like stdout, but affecting the command's error output. Also see `exe_log` for a simpler form of control.
         :type stderr: _FILE, optional
         :param cwd: The current working directory to run the command in. If None, no change will be done of the working directory. This may not work as wanted when using the simulator under wine.
-        :type cwd: Union[str, Path, None], optional        
-        :param exe_log: If True, stdout and stderr will be ignored, and the simulator's execution console messages will be written to a log file 
+        :type cwd: Union[str, pathlib.Path, None], optional
+        :param exe_log: If True, stdout and stderr will be ignored, and the simulator's execution console messages will be written to a log file
             (named ...exe.log) instead of console. This is especially useful when running under wine or when running simultaneous tasks.
         :type exe_log: bool, optional            
         :raises SpiceSimulatorError: when the executable is not found.

--- a/spicelib/simulators/qspice_simulator.py
+++ b/spicelib/simulators/qspice_simulator.py
@@ -151,7 +151,7 @@ class Qspice(Simulator):
         but with `.qraw` and `.log` extension. You can however change the raw file name using the `-r` switch.
 
         :param netlist_file: path to the netlist file
-        :type netlist_file: Union[str, Path]
+        :type netlist_file: Union[str, pathlib.Path]
         :param cmd_line_switches: additional command line options. Best to have been validated by valid_switch(), defaults to None
         :type cmd_line_switches: list, optional
         :param timeout: If timeout is given, and the process takes too long, a TimeoutExpired exception will be raised, defaults to None
@@ -163,8 +163,8 @@ class Qspice(Simulator):
         :param stderr: Like stdout, but affecting the command's error output. Also see `exe_log` for a simpler form of control.
         :type stderr: _FILE, optional
         :param cwd: The current working directory to run the command in. If None, no change will be done of the working directory. This may not work as wanted when using the simulator under wine.
-        :type cwd: Union[str, Path, None], optional        
-        :param exe_log: If True, stdout and stderr will be ignored, and the simulator's execution console messages will be written to a log file 
+        :type cwd: Union[str, pathlib.Path, None], optional
+        :param exe_log: If True, stdout and stderr will be ignored, and the simulator's execution console messages will be written to a log file
             (named ...exe.log) instead of console. This is especially useful when running under wine or when running simultaneous tasks.
         :type exe_log: bool, optional            
         :raises SpiceSimulatorError: when the executable is not found.

--- a/spicelib/simulators/xyce_simulator.py
+++ b/spicelib/simulators/xyce_simulator.py
@@ -228,7 +228,7 @@ class XyceSimulator(Simulator):
         but with `.raw` and `.log` extension.
         
         :param netlist_file: path to the netlist file
-        :type netlist_file: Union[str, Path]
+        :type netlist_file: Union[str, pathlib.Path]
         :param cmd_line_switches: additional command line options. Best to have been validated by valid_switch(), defaults to None
         :type cmd_line_switches: list, optional
         :param timeout: If timeout is given, and the process takes too long, a TimeoutExpired exception will be raised, defaults to None
@@ -240,8 +240,8 @@ class XyceSimulator(Simulator):
         :param stderr: Like stdout, but affecting the command's error output. Also see `exe_log` for a simpler form of control.
         :type stderr: _FILE, optional
         :param cwd: The current working directory to run the command in. If None, no change will be done of the working directory. This may not work as wanted when using the simulator under wine.
-        :type cwd: Union[str, Path, None], optional        
-        :param exe_log: If True, stdout and stderr will be ignored, and the simulator's execution console messages will be written to a log file 
+        :type cwd: Union[str, pathlib.Path, None], optional
+        :param exe_log: If True, stdout and stderr will be ignored, and the simulator's execution console messages will be written to a log file
             (named ...exe.log) instead of console. This is especially useful when running under wine or when running simultaneous tasks.
         :type exe_log: bool, optional            
         :raises SpiceSimulatorError: when the executable is not found.


### PR DESCRIPTION
* A fair amount of error checking was missing for SimServer/SimClient. That is repaired now.
* Added a parameter to RunTask and SimRunner that will allow returning of the log file in case of an error, even when a callback is used.
* SimServer will now try to return whatever is available. <= This is not fully backward compatible.
* (and standardised `pathlib.Path` vs `Path`, plus a lot of lint corrections)

@simonwaid, can you see if this is OK? 
Your test setup on SimServer is more aggressive than mine.