### PR TITLE
246 editor to string and line continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1052,6 +1052,7 @@ in [GitHub spicelib issues](https://github.com/nunobrum/spicelib/issues)
 ## History
 
 * Version 1.4.6
+    * Fixing Issue #246 - Correct line continuation handling in netlist
     * Fixing Issue #242 and #243 - Improve error handling in SimServer, and return log information in case of errors.
 * Version 1.4.5
     * Fixing Issue #235 and #236 - Inconsistent formulas in montecarlo.py and in tolerance_deviations.py

--- a/examples/testfiles/all_elements_lt.net
+++ b/examples/testfiles/all_elements_lt.net
@@ -65,6 +65,8 @@ M3 Nd Ng Ns Si4410DY
 *  Nxxx NI1 NI2...NIX mname [<parameter>=<value>] ...
 N1 z a vdd vdd BSIMBULK_osdi_P  l=0.1u 
 +  w=1u as=0.26235p  ad=0.26235p  ps=2.51u   pd=2.51u 
+N2 z a vdd vdd BSIMBULK_osdi_P  l=0.1u 
++  w=1u as=0.26235p  ad=0.26235p  ps=2.51u   pd=2.51u 
 
 * Oxxx L+ L- R+ R- <model>
 O1 NC_34 NC_35 NC_36 NC_37 LTRA

--- a/spicelib/editor/spice_editor.py
+++ b/spicelib/editor/spice_editor.py
@@ -536,8 +536,9 @@ class SpiceCircuit(BaseEditor):
                     return False                
             elif cmd == '+':
                 assert len(self.netlist) > 0, "ERROR: The first line cannot be starting with a +"
-                # TODO: maybe remove the '+' with line = line[1:]
-                self.netlist[-1] += line[1:]  # Append to the last line, but remove the leading '+'
+                # Concatenate the line to the previous line. Make it easy to handle: just make it 1 line. (but keep spaces etc)
+                lastline = self.netlist[-1].rstrip('\r\n')
+                self.netlist[-1] = lastline + line[1:]  # Append to the last line, but remove the preceding newline and the leading '+'
             elif len(cmd) == 1 and len(line) > 1 and line[1] == '§':
                 # strip any §, it is not always present and seems optional, so scrap it
                 line = line[0] + line[2:]
@@ -710,6 +711,7 @@ class SpiceCircuit(BaseEditor):
             return line
         
         section = section.strip()
+        # TODO why do we need a space? In the construction 'a=1' that must become 'a=2' a space shouyld not be needed.
         if start > 0 and line[start - 1] != ' ':
             section = ' ' + section
         if end < len(line) and line[end] != ' ' and len(section) > 1:

--- a/unittests/golden/all_elements_lt.net
+++ b/unittests/golden/all_elements_lt.net
@@ -64,6 +64,7 @@ M3 Nd Ng Ns 1e-9
 
 *  Nxxx NI1 NI2...NIX mname [<parameter>=<value>] ...
 N1 z a vdd vdd 1e-9 l=1e-09 w=1u as=0.26235p ps=2.51u pd=2.51u blabla=1 2 3 4 5 6 7
+N2 z a vdd vdd BSIMBULK_osdi_P  l=0.1u   w=1u as=0.26235p  ad=0.26235p  ps=2.51u   pd=2.51u 
 
 * Oxxx L+ L- R+ R- <model>
 O1 NC_34 NC_35 NC_36 NC_37 1e-9

--- a/unittests/test_spice_editor.py
+++ b/unittests/test_spice_editor.py
@@ -446,7 +446,8 @@ class SpiceEditor_Test(unittest.TestCase):
             "M2": ["BSP89", {"temp": 2}],
             "M3": ["Si4410DY", {}],
             #
-            "N1": ["BSIMBULK_osdi_P", {"as": "0.26235p", "ad": "0.26235p", "ps": "2.51u", "pd": "2.51u", "l": "0.1u", "w": "1u"}], 
+            "N1": ["BSIMBULK_osdi_P", {"as": "0.26235p", "ad": "0.26235p", "ps": "2.51u", "pd": "2.51u", "l": "0.1u", "w": "1u"}],
+            # N2 is mentioned not here on purpose, as it is identical to N1 and I want to see it unscatched at write time 
             #
             "O1": ["LTRA", {}],
             #


### PR DESCRIPTION
Line continuation handling was wrong: upon writing, newlines from line continuations could sometimes be replicated, but the '+' was never written at the start of the continuing line. The unit test in place just slipped through the cracks here.

This is solved now by accepting line continuations in the input (as before), but discarding them, and handle any fractioned line as a single combined line.

Unit test is also improved.

Maybe this creates problems with simulators that have line length limitations, but so far I haven't seen it. 
We had that problem anyway: it was possible to create very long lines via edits.

If we want to solve it properly, we should have a real netlist parser, that understands the syntax, and at write time, applies line breaks at the right places. 