### PR TITLE
256 adding a component to a netlist fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1125,7 +1125,8 @@ in [GitHub spicelib issues](https://github.com/nunobrum/spicelib/issues)
 ## History
 
 * Version 1.4.7
-    * Implementing a lazy loading approach in RawRead 
+    * Implementing a lazy loading approach in RawRead
+    * Fixing Issue #256 - Correct add_component() in SpiceEditor
 * Version 1.4.6
     * Fixing Issue #246 - Correct line continuation handling in netlist, correction to error introduced in 1.4.5
     * Fixing Issue #242 and #243 - Improve error handling in SimServer, and return log information in case of errors.

--- a/spicelib/editor/spice_editor.py
+++ b/spicelib/editor/spice_editor.py
@@ -1194,11 +1194,15 @@ class SpiceCircuit(BaseEditor):
                 line_no = len(self.netlist) - 2
 
         nodes = " ".join(component.ports)
-        model = component.attributes.get('model', None)
-        if model is None:
-            model = ''
-        else:
-            model = f" {model}"
+        # The code below is somewhat superfluous at the moment: 
+        #  Model and Value are used interchangeably and stored as Value.
+        # But this is what would be needed probably:
+        # model = component.attributes.get('model', None)
+        # if model is None:
+        #     model = ''
+        # else:
+        #     model = f" {model}"
+        model = ''
         value = component.attributes.get('value', None)
         if value is not None:
             if isinstance(value, (int, float)):

--- a/unittests/golden/test_components_output_3.net
+++ b/unittests/golden/test_components_output_3.net
@@ -1,0 +1,16 @@
+* C:\sandbox\spicelib\examples\testfiles\DC sweep.asc
+Vin in 0 1
+R1 in out 33k tol=1% Tc1=0 Tc2=0
+R2 out 0 {res}
+R3 in out 1Meg tol=1% pwr=0.1
+D1 out 0 D
+.model D D
+.lib C:\Users\nunob\AppData\Local\LTspice\lib\cmp\standard.dio
+.dc Vin 1 10 9
+.param res=10k
+.step temp 0 100 50
+* .step param res 1k 16k 5k
+.op
+.param temp = 0
+.backanno
+.end

--- a/unittests/test_spice_editor.py
+++ b/unittests/test_spice_editor.py
@@ -21,6 +21,7 @@
 import os
 import sys
 import unittest
+from copy import copy
 
 sys.path.append(
     os.path.abspath((os.path.dirname(os.path.abspath(__file__)) + "/../")))  # add project root to lib search path
@@ -99,6 +100,7 @@ class SpiceEditor_Test(unittest.TestCase):
     def test_component_editing_1_obj(self):
         self.assertListEqual(self.edt.get_components(), ['Vin', 'R1', 'R2', 'D1'], "Tested get_components")
         r1 = self.edt['R1']
+        r3 = copy(r1)
         self.assertEqual(r1.value_str, '10k', "Tested R1 Value")
         self.assertEqual(r1.value, 10000, "Tested R1 Numeric Value")
         self.assertListEqual(r1.ports, ['in', 'out'], "Tested R1 Nodes")
@@ -117,13 +119,19 @@ class SpiceEditor_Test(unittest.TestCase):
         self.check_update(self.edt, 'R1:pwr', UpdateType.DeleteComponentParameter, 0, 3)
         self.assertEqual(r1.params['Tc1'], 0, "Tested R1 Tc1 Parameter")
         self.assertEqual(r1.params['Tc2'], 0, "Tested R1 Tc2 Parameter")
-        self.edt.save_netlist(temp_dir + 'test_components_output_2.net')
-        self.equalFiles(temp_dir + 'test_components_output_2.net', golden_dir + 'test_components_output_2.net')
+        r3.reference = 'R3'
+        self.edt.add_component(r3, insert_after='R2')
+        r3 = self.edt['R3']
+        r3.value = '1Meg'
+        self.assertEqual(r3.value_str, '1Meg', "Tested R3 Value")
+        self.edt.save_netlist(temp_dir + 'test_components_output_3.net')
+        self.equalFiles(temp_dir + 'test_components_output_3.net', golden_dir + 'test_components_output_3.net')
         r1_params = self.edt.get_component_parameters('R1')
         for key, value in {'Tc1': 0, 'Tc2': 0}.items():
             self.assertEqual(r1_params[key], value, f"Tested R1 {key} Parameter")
             self.assertEqual(r1[key], value, f"Tested R1 {key} Parameter")
         self.edt.remove_component('R1')
+        self.edt.remove_component('R3')
         self.edt.save_netlist(temp_dir + 'test_components_output_1.net')
         self.equalFiles(temp_dir + 'test_components_output_1.net', golden_dir + 'test_components_output_1.net')
 


### PR DESCRIPTION
add_component() was way off, see #255.

A copy a I1 to make a new I2, with 'insert_after', gave:
```text
I2 In_A GND PULSE(0 5.803302283169387e-09 9e-06 0.1n 0.1n 0.9n) AC 0 DC 0 value=PULSE(0 4.955647818860598e-05 7.000000000000001e-06 0.1n 0.1n 0.9n) AC 1 DC 0 params={}
I1 In_A GND PULSE(0 4.955647818860598e-05 7.000000000000001e-06 0.1n 0.1n 0.9n) AC 1 DC 0
```
but should be:
```text
I1 In_A GND PULSE(0 4.955647818860598e-05 7.000000000000001e-06 0.1n 0.1n 0.9n) AC 1 DC 0
I2 In_A GND PULSE(0 5.803302283169387e-09 9e-06 0.1n 0.1n 0.9n) AC 0 DC 0
```
