### PR TITLE
fix: handle undefined 'exe' and other vars

### DIFF
--- a/spicelib/simulators/ltspice_simulator.py
+++ b/spicelib/simulators/ltspice_simulator.py
@@ -121,9 +121,11 @@ class LTspice(Simulator):
                 break
     
     # The following variables are not needed anymore. This also makes sphinx not mention them in the documentation.
-    del exe
-    if sys.platform == "linux" or sys.platform == "darwin":
+    if 'exe' in locals():
+        del exe
+    if 'spice_folder' in locals():
         del spice_folder
+    if 'spice_executable' in locals():
         del spice_executable
             
     # fall through        


### PR DESCRIPTION
Fixes a NameError that occurs when deleting `exe` with LTSPICEFOLDER or LTSPICEEXECUTABLE environment variables set.

Applied the same for `spice_folder` and `spice_executable` to keep things consistent.

Fixes #283 