### PR TITLE
Remove duplicate `'.DC'` item in `UNIQUE_SIMULATION_DOT_INSTRUCTIONS`

### DIFF
--- a/spicelib/editor/base_editor.py
+++ b/spicelib/editor/base_editor.py
@@ -39,7 +39,7 @@ ValueType: TypeAlias = str | float | int | complex
 SUBCKT_DIVIDER = ':'  #: This controls the sub-circuit divider when setting component values inside sub-circuits.
 # Ex: Editor.set_component_value('XU1:R1', '1k')
 
-UNIQUE_SIMULATION_DOT_INSTRUCTIONS = ('.AC', '.DC', '.TRAN', '.NOISE', '.DC', '.TF')
+UNIQUE_SIMULATION_DOT_INSTRUCTIONS = ('.AC', '.DC', '.TRAN', '.NOISE', '.TF')
 SPICE_DOT_INSTRUCTIONS = (
     '.BACKANNO',
     '.END',

--- a/spicelib/editor/base_editor.py
+++ b/spicelib/editor/base_editor.py
@@ -21,7 +21,7 @@ __copyright__ = "Copyright 2021, Fribourg Switzerland"
 
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from typing import TypeAlias
+from typing import Final, TypeAlias
 from math import floor, log
 from pathlib import Path
 import logging
@@ -36,11 +36,11 @@ _logger = logging.getLogger("spicelib.BaseEditor")
 
 ValueType: TypeAlias = str | float | int | complex
 
-SUBCKT_DIVIDER = ':'  #: This controls the sub-circuit divider when setting component values inside sub-circuits.
+SUBCKT_DIVIDER: Final[str] = ':'  #: This controls the sub-circuit divider when setting component values inside sub-circuits.
 # Ex: Editor.set_component_value('XU1:R1', '1k')
 
-UNIQUE_SIMULATION_DOT_INSTRUCTIONS = ('.AC', '.DC', '.TRAN', '.NOISE', '.TF')
-SPICE_DOT_INSTRUCTIONS = (
+UNIQUE_SIMULATION_DOT_INSTRUCTIONS: Final[tuple[str, ...]] = ('.AC', '.DC', '.TRAN', '.NOISE', '.TF')
+SPICE_DOT_INSTRUCTIONS: Final[tuple[str, ...]] = (
     '.BACKANNO',
     '.END',
     '.ENDS',


### PR DESCRIPTION
While working on Python 3.10 annotations I noticed a duplicated `'.DC'` item in `UNIQUE_SIMULATION_DOT_INSTRUCTIONS` . Let's remove it :)

Added type annotation to surrounding code.