### PR TITLE
Fixing issue 309

### DIFF
--- a/README.md
+++ b/README.md
@@ -1136,7 +1136,7 @@ in [GitHub spicelib issues](https://github.com/nunobrum/spicelib/issues)
 * Version 1.6.3
   *  Enhancements to subcircuit and parameter editing, Unit test expansion and golden file updates,
   SPICE netlist writing improvements, Documentation and usability andTesting and debugging.
-  * Fixing issue #309 - Support for "params:" declaration in subcircuit definitions
+  * Fixing issue #309 - Support for "params:" declaration in subcircuit instances
 * Version 1.6.2
   * method get_component_value() always return a string value
 * Version 1.6.1

--- a/README.md
+++ b/README.md
@@ -1136,6 +1136,7 @@ in [GitHub spicelib issues](https://github.com/nunobrum/spicelib/issues)
 * Version 1.6.3
   *  Enhancements to subcircuit and parameter editing, Unit test expansion and golden file updates,
   SPICE netlist writing improvements, Documentation and usability andTesting and debugging.
+  * Fixing issue #309 - Support for "params:" declaration in subcircuit definitions
 * Version 1.6.2
   * method get_component_value() always return a string value
 * Version 1.6.1

--- a/spicelib/editor/spice_subcircuit_instance.py
+++ b/spicelib/editor/spice_subcircuit_instance.py
@@ -24,7 +24,7 @@ from .base_editor import BaseEditor
 from .base_subcircuit import BaseSubCircuitInstance, BaseSubCircuit
 from .primitives import VALUE_IDs, PARAMS_IDs, Component, ValueType
 from .updates import UpdateType, UpdatePermission
-from .spice_components import SpiceComponent, component_replace_regexs, _parse_params, undress_designator
+from .spice_components import SpiceComponent
 
 logger = logging.getLogger("spicelib.SpiceEditor")
 

--- a/spicelib/editor/spice_subcircuit_instance.py
+++ b/spicelib/editor/spice_subcircuit_instance.py
@@ -42,20 +42,9 @@ class SpiceCircuitInstance(SpiceComponent, BaseSubCircuitInstance):
 
     def reset_attributes(self):
         """Resets the sub-circuit instance to its original state."""
-        line: str = self._obj  # pyright: ignore[reportAssignmentType]
-        new_line = re.sub(r'[\n\r]+\s*', ' ', line)  # cleans up line breaks and extra spaces and tabs
-        regex = component_replace_regexs['X']
-        match = regex.match(new_line)
-        self._attributes.clear()
-        if match:
-            ref = match.group('designator')
-            self._reference = undress_designator(ref)
-            self._set_ports(match.group('nodes').strip().split())
-            self._attributes['value'] =match.group('value').strip()
-            if match.group('params'):
-                self._attributes['params'] = _parse_params(match.group('params'))
-            # The instruction below might fail if the sub-circuit was not parsed in the parent netlist.
-            self._subcircuit = self._netlist.get_subcircuit_named(self.value)  # In case it isn't given, get it from the parent
+        super().reset_attributes()
+        # The instruction below might fail if the sub-circuit was not parsed in the parent netlist.
+        self._subcircuit = self._netlist.get_subcircuit_named(self.value)  # In case it isn't given, get it from the parent
 
     @property
     def subcircuit(self):

--- a/spicelib/editor/spice_utils.py
+++ b/spicelib/editor/spice_utils.py
@@ -241,7 +241,7 @@ REPLACE_REGEXS : Dict[str, str] = {
     # ex: XU1 NC_01 NC_02 NC_03 NC_04 NC_05 level2 Avol=1Meg GBW=10Meg Slew=10Meg Ilimit=25m Rail=0 Vos=0 En=0 Enk=0 In=0 Ink=0 Rin=500Meg
     #     XU1 in out1 -V +V out1 OPAx189 bla_v2 =1% bla_sp1=2 bla_sp2 = 3
     #     XU1 in out1 -V +V out1 GND OPAx189_float
-    'X': PREFIX_AND_NODES_RGX("X", 1, 99) + MODEL_OR_VALUE_RGX + r"(?:\s+(?P<params>(?:\w+\s*=\s*['\"{]?.*?['\"}]?\s*)+))?" + COMMENT_RGX,  # Subcircuit Instance
+    'X': PREFIX_AND_NODES_RGX("X", 1, 99) + MODEL_OR_VALUE_RGX + r"(?:\s+params\:)?(?:\s+(?P<params>(?:\w+\s*=\s*['\"{]?.*?['\"}]?\s*)+))?" + COMMENT_RGX,  # Subcircuit Instance
     # (ngspice) Yxxx N1 0 N2 0 mname <LEN=LENGTH>
     # (qspice) Ynnn N+ N- <frequency1> dF=<value> Ctot=<value> [Q=<value>]
     'Y': PREFIX_AND_NODES_RGX("Y", 2, 4) + MODEL_OR_VALUE_RGX + PARAM_RGX,  # Single Lossy Transmission Line

--- a/spicelib/editor/spice_utils.py
+++ b/spicelib/editor/spice_utils.py
@@ -241,7 +241,7 @@ REPLACE_REGEXS : Dict[str, str] = {
     # ex: XU1 NC_01 NC_02 NC_03 NC_04 NC_05 level2 Avol=1Meg GBW=10Meg Slew=10Meg Ilimit=25m Rail=0 Vos=0 En=0 Enk=0 In=0 Ink=0 Rin=500Meg
     #     XU1 in out1 -V +V out1 OPAx189 bla_v2 =1% bla_sp1=2 bla_sp2 = 3
     #     XU1 in out1 -V +V out1 GND OPAx189_float
-    'X': PREFIX_AND_NODES_RGX("X", 1, 99) + MODEL_OR_VALUE_RGX + r"(?:\s+params\:)?(?:\s+(?P<params>(?:\w+\s*=\s*['\"{]?.*?['\"}]?\s*)+))?" + COMMENT_RGX,  # Subcircuit Instance
+'X': PREFIX_AND_NODES_RGX("X", 1, 99) + MODEL_OR_VALUE_RGX + r"(?:\s+(?:params\:\s*)?(?P<params>(?:\w+\s*=\s*['\"{]?.*?['\"}]?\s*)+))?" + COMMENT_RGX,  # Subcircuit Instance
     # (ngspice) Yxxx N1 0 N2 0 mname <LEN=LENGTH>
     # (qspice) Ynnn N+ N- <frequency1> dF=<value> Ctot=<value> [Q=<value>]
     'Y': PREFIX_AND_NODES_RGX("Y", 2, 4) + MODEL_OR_VALUE_RGX + PARAM_RGX,  # Single Lossy Transmission Line


### PR DESCRIPTION
This pull request refactors how subcircuit instance attributes are reset and updates the parsing logic for subcircuit parameters in SPICE netlists. The most important changes are:

### Refactoring and Simplification

* The `reset_attributes` method in `spicelib/editor/spice_subcircuit_instance.py` now delegates attribute resetting to its superclass by calling `super().reset_attributes()`, removing custom parsing logic from this method.

### Parsing Logic Improvements

* The regular expression for parsing subcircuit instances (`'X'` entries) in `spicelib/editor/spice_utils.py` has been updated to optionally allow a `params:` prefix before parameter assignments, improving compatibility with different SPICE netlist formats.

This fixes issue #309 