### PR TITLE
Add curly expressions to value argument for K component

### DIFF
--- a/spicelib/editor/spice_utils.py
+++ b/spicelib/editor/spice_utils.py
@@ -199,7 +199,9 @@ REPLACE_REGEXS : Dict[str, str] = {
     # Jxxx D G S <model> [area] [off] [IC=Vds, Vgs] [temp=T]
     'J': PREFIX_AND_NODES_RGX("J", 3) + MODEL_OR_VALUE_RGX + PARAM_RGX,  # JFET
     # Kxxx Lyyy Lzzz ... value
-    'K': PREFIX_AND_NODES_RGX("K", 2, 99) + r"\s+(?P<value>[\+\-]?[0-9\.E+-]+[kmuµnpgt]?)" + COMMENT_RGX,  # Mutual Inductance
+    'K': PREFIX_AND_NODES_RGX("K", 2, 99) \
+         + r"\s+(?P<value>(?:[\+\-]?[0-9\.E+-]+[kmuµnpgt]?)|(?:{.*}))" \
+         + COMMENT_RGX,  # Mutual Inductance
     # Lxxx n+ n- <value> <mname> <nt=val> <m=val> ...
     # Lxxx n+ n- L = 'expression' <tc1=value> <tc2=value>
     'L': PREFIX_AND_NODES_RGX("L", 2) + VALUE_RGX("L", r"(Meg|[kmuµnpgt])?H?\d*") + PARAM_RGX,  # Inductance


### PR DESCRIPTION
Feel free to adopt this change in other components.
No AI was involved in this PR.

Here is the regex test: https://regex101.com/r/gYjzRT/1

And the error:

```
UnrecognizedSyntaxError: Line: "K12 L1 L2 {0.499 * (1 + yat_Lr)}
" doesn't match regular expression "^(?P<designator>K§?\w+)(?P<nodes>(?:\s+[\w+-\.¥«»]+){2,99})\s+(?P<value>[\+\-]?[0-9\.E+-]+[kmuµnpgt]?)(?:\s+;.*)?\\?\s*$"
```

I don't currently have the bandwidth to implement tests, I'm sorry.
As always, thanks for maintaining the package.